### PR TITLE
Fixed loss of exception when exception has no cause

### DIFF
--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/Utils.kt
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/Utils.kt
@@ -98,7 +98,7 @@ internal fun executeActor(
         val res = m.invoke(testInstance, *args.toTypedArray())
         return if (m.returnType.isAssignableFrom(Void.TYPE)) VoidResult else createLinCheckResult(res)
     } catch (invE: Throwable) {
-        val eClass = invE.cause!!::class.java
+        val eClass = (invE.cause ?: invE)::class.java
         for (ec in actor.handledExceptions) {
             if (ec.isAssignableFrom(eClass))
                 return ExceptionResult(eClass)


### PR DESCRIPTION
Without it some exceptions such as `OutOfMemoryError` are replaced with `NullPointerException` loosing all information about them.

Or when a method with `@Operation` annotation is not public a `NullPointerException` is thrown.