### PR TITLE
Scenario minimization

### DIFF
--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/CTestConfiguration.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/CTestConfiguration.java
@@ -49,6 +49,7 @@ public abstract class CTestConfiguration {
     public static final int DEFAULT_ACTORS_AFTER = 5;
     public static final Class<? extends ExecutionGenerator> DEFAULT_EXECUTION_GENERATOR = RandomExecutionGenerator.class;
     public static final Class<? extends Verifier> DEFAULT_VERIFIER = LinearizabilityVerifier.class;
+    public static final boolean DEFAULT_MINIMIZE_ERROR = true;
 
     public final int iterations;
     public final int threads;
@@ -59,9 +60,11 @@ public abstract class CTestConfiguration {
     public final Class<? extends Verifier> verifierClass;
     public boolean hasTestClassSuspendableActors;
     public final boolean requireStateEquivalenceImplCheck;
+    public final Boolean minimizeFailedScenario;
 
     protected CTestConfiguration(int iterations, int threads, int actorsPerThread, int actorsBefore, int actorsAfter,
-        Class<? extends ExecutionGenerator> generatorClass, Class<? extends Verifier> verifierClass, boolean requireStateEquivalenceImplCheck)
+        Class<? extends ExecutionGenerator> generatorClass, Class<? extends Verifier> verifierClass,
+        boolean requireStateEquivalenceImplCheck, boolean minimizeFailedScenario)
     {
         this.iterations = iterations;
         this.threads = threads;
@@ -71,6 +74,7 @@ public abstract class CTestConfiguration {
         this.generatorClass = generatorClass;
         this.verifierClass = verifierClass;
         this.requireStateEquivalenceImplCheck = requireStateEquivalenceImplCheck;
+        this.minimizeFailedScenario = minimizeFailedScenario;
     }
 
     static List<CTestConfiguration> createFromTestClass(Class<?> testClass) {
@@ -83,7 +87,8 @@ public abstract class CTestConfiguration {
                 }
                 return new StressCTestConfiguration(ann.iterations(),
                         ann.threads(), ann.actorsPerThread(), ann.actorsBefore(), ann.actorsAfter(),
-                        ann.generator(), ann.verifier(), ann.invocationsPerIteration(), true, ann.requireStateEquivalenceImplCheck());
+                        ann.generator(), ann.verifier(), ann.invocationsPerIteration(), true,
+                        ann.requireStateEquivalenceImplCheck(), ann.minimizeFailedScenario());
             });
         Stream<RandomSwitchCTestConfiguration> randomSwitchConfigurations = Arrays.stream(testClass.getAnnotationsByType(RandomSwitchCTest.class))
             .map(ann -> {
@@ -92,7 +97,8 @@ public abstract class CTestConfiguration {
                 }
                 return new RandomSwitchCTestConfiguration(ann.iterations(),
                         ann.threads(), ann.actorsPerThread(), ann.actorsBefore(), ann.actorsAfter(),
-                        ann.generator(), ann.verifier(), ann.invocationsPerIteration(), ann.requireStateEquivalenceImplCheck());
+                        ann.generator(), ann.verifier(), ann.invocationsPerIteration(),
+                        ann.requireStateEquivalenceImplCheck(), ann.minimizeFailedScenario());
             });
         return Stream.concat(stressConfigurations, randomSwitchConfigurations).collect(Collectors.toList());
     }

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/Options.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/Options.java
@@ -42,6 +42,7 @@ public abstract class Options<OPT extends Options, CTEST extends CTestConfigurat
     protected Class<? extends ExecutionGenerator> executionGenerator = CTestConfiguration.DEFAULT_EXECUTION_GENERATOR;
     protected Class<? extends Verifier> verifier = CTestConfiguration.DEFAULT_VERIFIER;
     protected boolean requireStateEquivalenceImplementationCheck = true;
+    protected boolean minimizeFailedScenario = CTestConfiguration.DEFAULT_MINIMIZE_ERROR;
 
     /**
      * Number of different test scenarios to be executed
@@ -126,6 +127,17 @@ public abstract class Options<OPT extends Options, CTEST extends CTestConfigurat
      */
     public OPT requireStateEquivalenceImplCheck(boolean require) {
         this.requireStateEquivalenceImplementationCheck = require;
+        return (OPT) this;
+    }
+
+    /**
+     * If this feature is enabled and an invalid interleaving has been found,
+     * *lincheck* tries to minimize the corresponding scenario in order to
+     * construct a smaller one so that the test fails on it as well.
+     * Enabled by default.
+     */
+    public OPT minimizeFailedScenario(boolean minimizeFailedScenario) {
+        this.minimizeFailedScenario = minimizeFailedScenario;
         return (OPT) this;
     }
 

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/Reporter.kt
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/Reporter.kt
@@ -29,9 +29,15 @@ import java.io.PrintStream
 class Reporter @JvmOverloads constructor(val logLevel: LoggingLevel, val out: PrintStream = System.out) {
     fun logIteration(iteration: Int, maxIterations: Int, scenario: ExecutionScenario) = synchronized(this) {
         if (logLevel > LoggingLevel.INFO) return
-        out.println()
-        out.println("= Iteration $iteration / $maxIterations =")
-        StringBuilder().run {
+        StringBuilder("\n= Iteration $iteration / $maxIterations =\n").run {
+            appendExecutionScenario(scenario)
+            out.println(this)
+        }
+    }
+
+    fun logScenarioMinimization(scenario: ExecutionScenario) {
+        if (logLevel > LoggingLevel.INFO) return
+        StringBuilder("\nInvalid interleaving found, trying to minimize the scenario below:\n").run {
             appendExecutionScenario(scenario)
             out.println(this)
         }
@@ -73,6 +79,7 @@ private fun uniteActorsAndResults(actors: List<Actor>, results: List<Result>): L
     require(actors.size == results.size) {
         "Different numbers of actors and matching results found (${actors.size} != ${results.size})"
     }
+    val actorRepresentations = actors.map { it.toString() }
     return actors.indices.map { ActorWithResult("${actors[it]}", 1, "${results[it]}") }
 }
 

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/randomswitch/RandomSwitchCTest.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/randomswitch/RandomSwitchCTest.java
@@ -108,6 +108,14 @@ public @interface RandomSwitchCTest {
     boolean requireStateEquivalenceImplCheck() default true;
 
     /**
+     * If this feature is enabled and an invalid interleaving has been found,
+     * *lincheck* tries to minimize the corresponding scenario in order to
+     * construct a smaller one so that the test fails on it as well.
+     * Enabled by default.
+     */
+    boolean minimizeFailedScenario() default true;
+
+    /**
      * Holder annotation for {@link RandomSwitchCTest}.
      * Not a public API.
      */

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/randomswitch/RandomSwitchCTestConfiguration.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/randomswitch/RandomSwitchCTestConfiguration.java
@@ -35,9 +35,10 @@ public class RandomSwitchCTestConfiguration extends CTestConfiguration {
 
     public RandomSwitchCTestConfiguration(int iterations, int threads, int actorsPerThread, int actorsBefore,
         int actorsAfter, Class<? extends ExecutionGenerator> generatorClass, Class<? extends Verifier> verifierClass,
-        int invocationsPerIteration, boolean requireStateEquivalenceCheck)
+        int invocationsPerIteration, boolean requireStateEquivalenceCheck, boolean minimizeFailedScenario)
     {
-        super(iterations, threads, actorsPerThread, actorsBefore, actorsAfter, generatorClass, verifierClass, requireStateEquivalenceCheck);
+        super(iterations, threads, actorsPerThread, actorsBefore, actorsAfter, generatorClass, verifierClass,
+                requireStateEquivalenceCheck, minimizeFailedScenario);
         this.invocationsPerIteration = invocationsPerIteration;
     }
 }

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/randomswitch/RandomSwitchOptions.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/randomswitch/RandomSwitchOptions.java
@@ -41,6 +41,6 @@ public class RandomSwitchOptions extends Options<RandomSwitchOptions, RandomSwit
     @Override
     public RandomSwitchCTestConfiguration createTestConfigurations() {
         return new RandomSwitchCTestConfiguration(iterations, threads, actorsPerThread, actorsBefore, actorsAfter,
-            executionGenerator, verifier, invocationsPerIteration, requireStateEquivalenceImplementationCheck);
+            executionGenerator, verifier, invocationsPerIteration, requireStateEquivalenceImplementationCheck, minimizeFailedScenario);
     }
 }

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTest.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTest.java
@@ -108,6 +108,14 @@ public @interface StressCTest {
     boolean requireStateEquivalenceImplCheck() default true;
 
     /**
+     * If this feature is enabled and an invalid interleaving has been found,
+     * *lincheck* tries to minimize the corresponding scenario in order to
+     * construct a smaller one so that the test fails on it as well.
+     * Enabled by default.
+     */
+    boolean minimizeFailedScenario() default true;
+
+    /**
      * Holder annotation for {@link StressCTest}.
      * Not a public API.
      */

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTestConfiguration.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTestConfiguration.java
@@ -37,9 +37,10 @@ public class StressCTestConfiguration extends CTestConfiguration {
 
     public StressCTestConfiguration(int iterations, int threads, int actorsPerThread, int actorsBefore, int actorsAfter,
         Class<? extends ExecutionGenerator> generatorClass, Class<? extends Verifier> verifierClass,
-        int invocationsPerIteration, boolean addWaits, boolean requireStateEquivalenceCheck)
+        int invocationsPerIteration, boolean addWaits, boolean requireStateEquivalenceCheck, boolean minimizeFailedScenario)
     {
-        super(iterations, threads, actorsPerThread, actorsBefore, actorsAfter, generatorClass, verifierClass, requireStateEquivalenceCheck);
+        super(iterations, threads, actorsPerThread, actorsBefore, actorsAfter, generatorClass, verifierClass,
+                requireStateEquivalenceCheck, minimizeFailedScenario);
         this.invocationsPerIteration = invocationsPerIteration;
         this.addWaits = addWaits;
     }

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/stress/StressOptions.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/stress/StressOptions.java
@@ -49,7 +49,7 @@ public class StressOptions extends Options<StressOptions, StressCTestConfigurati
 
     @Override
     public StressCTestConfiguration createTestConfigurations() {
-        return new StressCTestConfiguration(iterations, threads, actorsPerThread, actorsBefore, actorsAfter,
-            executionGenerator, verifier, invocationsPerIteration, addWaits, requireStateEquivalenceImplementationCheck);
+        return new StressCTestConfiguration(iterations, threads, actorsPerThread, actorsBefore, actorsAfter, executionGenerator,
+                verifier, invocationsPerIteration, addWaits, requireStateEquivalenceImplementationCheck, minimizeFailedScenario);
     }
 }

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/verifier/quantitative/QuantitativelyRelaxedLinearizabilityContext.kt
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/verifier/quantitative/QuantitativelyRelaxedLinearizabilityContext.kt
@@ -29,6 +29,7 @@ import org.jetbrains.kotlinx.lincheck.verifier.TransitionInfo
 import org.jetbrains.kotlinx.lincheck.verifier.VerifierContext
 import org.jetbrains.kotlinx.lincheck.*
 import org.jetbrains.kotlinx.lincheck.verifier.isRelaxed
+import java.lang.IndexOutOfBoundsException
 
 class QuantitativelyRelaxedLinearizabilityContext(
     scenario: ExecutionScenario,

--- a/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/FailedScenarioMinimizationTest.kt
+++ b/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/FailedScenarioMinimizationTest.kt
@@ -1,0 +1,56 @@
+package org.jetbrains.kotlinx.lincheck.test
+
+import org.jetbrains.kotlinx.lincheck.LinChecker
+import org.jetbrains.kotlinx.lincheck.annotations.Operation
+import org.jetbrains.kotlinx.lincheck.annotations.Param
+import org.jetbrains.kotlinx.lincheck.paramgen.IntGen
+import org.jetbrains.kotlinx.lincheck.strategy.stress.StressOptions
+import org.jetbrains.kotlinx.lincheck.verifier.VerifierState
+import org.junit.Assert.*
+import org.junit.Test
+import java.lang.AssertionError
+
+@Param(name = "key", gen = IntGen::class, conf = "1:5")
+class FailedScenarioMinimizationTest: VerifierState() {
+    private val m = HashMap<Int, Int>()
+    override fun extractState() = m
+
+    @Operation
+    fun put(@Param(name = "key") key: Int, @Param(gen = IntGen::class) value: Int) = m.put(key, value)
+
+    @Operation
+    fun get(@Param(name = "key") key: Int) = m.get(key)
+
+    @Operation
+    fun remove(@Param(name = "key") key: Int) = m.remove(key)
+
+    @Test
+    fun testWithoutMinimization() {
+        val options = StressOptions().actorsPerThread(15).minimizeFailedScenario(false)
+        try {
+            LinChecker.check(FailedScenarioMinimizationTest::class.java, options)
+            fail("Should fail with AssertionError")
+        } catch (e: AssertionError) {
+            val m = e.message!!
+            assertTrue("The init part should NOT be minimized", m.contains("Init"))
+            assertTrue("The post part should NOT be minimized", m.contains("Post"))
+            assertEquals("The parallel part should NOT be minimized",
+                    15, m.lines().filter { it.contains("|") }.size)
+        }
+    }
+
+    @Test
+    fun testWithMinimization() {
+        val options = StressOptions().actorsPerThread(15) // minimizeFailedScenario == true by default
+        try {
+            LinChecker.check(FailedScenarioMinimizationTest::class.java, options)
+            fail("Should fail with AssertionError")
+        } catch (e: AssertionError) {
+            val m = e.message!!
+            assertFalse("The init part should be minimized", m.contains("Init"))
+            assertFalse("The post part should be minimized", m.contains("Post"))
+            assertEquals("The error should be reproduced with one operation per thread",
+                    1, m.lines().filter { it.contains("|") }.size)
+        }
+    }
+}

--- a/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/strategy/randomswitch/RandomSwitchOptionsTest.java
+++ b/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/strategy/randomswitch/RandomSwitchOptionsTest.java
@@ -50,7 +50,8 @@ public class RandomSwitchOptionsTest {
             .threads(2)
             .actorsPerThread(4)
             .verifier(LinearizabilityVerifier.class)
-            .requireStateEquivalenceImplCheck(false);
+            .requireStateEquivalenceImplCheck(false)
+            .minimizeFailedScenario(false);
         LinChecker.check(RandomSwitchOptionsTest.class, opts);
     }
 }

--- a/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/strategy/stress/StressOptionsTest.java
+++ b/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/strategy/stress/StressOptionsTest.java
@@ -52,7 +52,8 @@ public class StressOptionsTest {
             .threads(2)
             .actorsPerThread(3)
             .logLevel(LoggingLevel.INFO)
-            .requireStateEquivalenceImplCheck(false);
+            .requireStateEquivalenceImplCheck(false)
+            .minimizeFailedScenario(false);
         LinChecker.check(StressOptionsTest.class, opts);
     }
 }


### PR DESCRIPTION
A feature to minimise scenarios with incorrect executions so that instead of huge messages like the following one
```
= Invalid execution results: =
Init part:
[put(1, 2): null, put(4, 6): null, get(5): null, put(3, -6): null, put(1, -8): 2]
Parallel part:
| get(4):     6    | put(2, 1):  null |
| get(2):     null | put(5, 4):  null |
| put(5, -8): null | get(3):     -6   |
| get(3):     -6   | get(4):     6    |
| put(3, 5):  -6   | put(1, -4): -8   |
Post part:
[put(5, -8): 4, put(5, -2): -8, get(1): -4, put(2, -8): 1, get(1): -4]
```
we get just a short minimized scenario
```
= Invalid execution results: =
Parallel part:
| put(5, -8): null | put(5, 4): null |
```
