### PR TITLE
Fixed 'Class' instead of exception name in report

### DIFF
--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/Result.kt
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/Result.kt
@@ -58,7 +58,7 @@ object VoidResult : Result() {
  * Type of result used if the actor invocation fails with the specified in {@link Operation#handleExceptionsAsResult()} exception [tClazz].
  */
 data class ExceptionResult(val tClazz: Class<out Throwable>?) : Result() {
-    override fun toString() = if (wasSuspended) "(${tClazz?.javaClass?.simpleName}, wasSuspended)" else "${tClazz?.javaClass?.simpleName}"
+    override fun toString() = if (wasSuspended) "(${tClazz?.simpleName}, wasSuspended)" else "${tClazz?.simpleName}"
 }
 
 /**

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/Strategy.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/Strategy.java
@@ -34,6 +34,8 @@ import org.jetbrains.kotlinx.lincheck.verifier.Verifier;
 import com.devexperts.jagent.ClassInfo;
 import org.objectweb.asm.ClassVisitor;
 
+import static org.jetbrains.kotlinx.lincheck.ReporterKt.appendIncorrectResults;
+
 /**
  * Implementation of this class describes how to run the generated execution.
  * <p>
@@ -54,8 +56,9 @@ public abstract class Strategy {
 
     protected void verifyResults(ExecutionResult results) {
         if (!verifier.verifyResults(results)) {
-            reporter.logIncorrectResults(scenario, results);
-            throw new AssertionError("Invalid interleaving found");
+            StringBuilder msgBuilder = new StringBuilder("Invalid interleaving found:\n");
+            appendIncorrectResults(msgBuilder, scenario, results);
+            throw new AssertionError(msgBuilder.toString());
         }
     }
 


### PR DESCRIPTION
Output in case of exceptions looked like
```
getOrException(1): Class
```
(i.e. exception name was lost)
Will be
```
getOrException(1): NoSuchElementException
```