### PR TITLE
Allow `actorsAfter` being greater than 0

### DIFF
--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/CTestConfiguration.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/CTestConfiguration.java
@@ -58,7 +58,6 @@ public abstract class CTestConfiguration {
     public final int actorsAfter;
     public final Class<? extends ExecutionGenerator> generatorClass;
     public final Class<? extends Verifier> verifierClass;
-    public boolean hasTestClassSuspendableActors;
     public final boolean requireStateEquivalenceImplCheck;
     public final Boolean minimizeFailedScenario;
 
@@ -81,15 +80,10 @@ public abstract class CTestConfiguration {
         boolean hasTestClassSuspendableActors = Arrays.stream(testClass.getDeclaredMethods()).anyMatch(m -> m.isAnnotationPresent(Operation.class) &&
                 m.getParameterTypes().length > 0 && m.getParameterTypes()[m.getParameterTypes().length - 1].isAssignableFrom(kotlin.coroutines.Continuation.class));
         Stream<StressCTestConfiguration> stressConfigurations = Arrays.stream(testClass.getAnnotationsByType(StressCTest.class))
-            .map(ann -> {
-                if (hasTestClassSuspendableActors && ann.actorsAfter() > 0) {
-                    throw new IllegalArgumentException("Post execution part is not allowed for test classes with suspendable operations");
-                }
-                return new StressCTestConfiguration(ann.iterations(),
-                        ann.threads(), ann.actorsPerThread(), ann.actorsBefore(), ann.actorsAfter(),
-                        ann.generator(), ann.verifier(), ann.invocationsPerIteration(), true,
-                        ann.requireStateEquivalenceImplCheck(), ann.minimizeFailedScenario());
-            });
+            .map(ann -> new StressCTestConfiguration(ann.iterations(),
+                    ann.threads(), ann.actorsPerThread(), ann.actorsBefore(), ann.actorsAfter(),
+                    ann.generator(), ann.verifier(), ann.invocationsPerIteration(), true,
+                    ann.requireStateEquivalenceImplCheck(), ann.minimizeFailedScenario()));
         Stream<RandomSwitchCTestConfiguration> randomSwitchConfigurations = Arrays.stream(testClass.getAnnotationsByType(RandomSwitchCTest.class))
             .map(ann -> {
                 if (hasTestClassSuspendableActors && ann.actorsAfter() > 0) {

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/LinChecker.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/LinChecker.java
@@ -27,7 +27,6 @@ import org.jetbrains.kotlinx.lincheck.execution.*;
 import org.jetbrains.kotlinx.lincheck.strategy.Strategy;
 import org.jetbrains.kotlinx.lincheck.verifier.*;
 import org.jetbrains.kotlinx.lincheck.verifier.quantitative.QuantitativeRelaxationVerifierConf;
-import static org.jetbrains.kotlinx.lincheck.ActorKt.isSuspendable;
 import static org.jetbrains.kotlinx.lincheck.ReporterKt.DEFAULT_LOG_LEVEL;
 import static org.jetbrains.kotlinx.lincheck.UtilsKt.createTestInstance;
 import java.util.*;
@@ -186,10 +185,10 @@ public class LinChecker {
     }
 
     private void validateScenario(CTestConfiguration testCfg, ExecutionScenario scenario) {
-        if (testCfg.hasTestClassSuspendableActors) {
-            if (scenario.initExecution.stream().anyMatch(actor -> isSuspendable(actor.getMethod())))
+        if (scenario.hasSuspendableActors()) {
+            if (scenario.initExecution.stream().anyMatch(Actor::isSuspendable))
                 throw new IllegalArgumentException("Generated execution scenario for the test class with suspendable methods contains suspendable actors in initial part");
-            if (scenario.postExecution.size() > 0)
+            if (scenario.parallelExecution.stream().anyMatch(actors -> actors.stream().anyMatch(Actor::isSuspendable)) && scenario.postExecution.size() > 0)
                 throw new IllegalArgumentException("Generated execution scenario for the test class with suspendable methods has non-empty post part");
         }
     }

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/execution/ExecutionGenerator.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/execution/ExecutionGenerator.java
@@ -45,8 +45,8 @@ public abstract class ExecutionGenerator {
      * Generates an execution scenario according to the parameters provided by the test configuration
      * and the restrictions from the test structure.
      *
-     * If the current test contains suspendable operations (see {@link CTestConfiguration#hasTestClassSuspendableActors}),
-     * the initial part of an execution should not contain suspendable actors and the post part should be empty.
+     * If the current test contains suspendable operations, the initial part of an execution
+     * should not contain suspendable actors and the post part should be empty.
      */
     public abstract ExecutionScenario nextExecution();
 }

--- a/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/linearizability/BufferedChannelStressTest.kt
+++ b/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/linearizability/BufferedChannelStressTest.kt
@@ -32,9 +32,8 @@ import org.jetbrains.kotlinx.lincheck.verifier.VerifierState
 import org.junit.Test
 
 @Param(name = "value", gen = IntGen::class, conf = "1:5")
-@StressCTest(verifier = LinearizabilityVerifier::class, actorsAfter = 0)
-class BufferedChannelMixedStressTest : VerifierState() {
-
+@StressCTest(verifier = LinearizabilityVerifier::class)
+class BufferedChannelStressTest : VerifierState() {
     val ch = Channel<Int>(2)
 
     @Operation
@@ -50,12 +49,14 @@ class BufferedChannelMixedStressTest : VerifierState() {
     fun offer(@Param(name = "value") value: Int) = ch.offer(value)
 
     @Test
-    fun test() = LinChecker.check(BufferedChannelMixedStressTest::class.java)
+    fun test() = LinChecker.check(BufferedChannelStressTest::class.java)
 
     override fun extractState(): Any {
-        val elements = mutableListOf<Int>()
-        while (!ch.isEmpty) elements.add(ch.poll()!!)
-        val closed = ch.isClosedForSend || ch.isClosedForReceive
-        return elements to closed
+        val state = mutableListOf<Any>()
+        while (true) {
+            val x = poll() ?: break // no elements
+            state.add(x)
+        }
+        return state
     }
 }


### PR DESCRIPTION
Allow `actorsAfter` to be greater than 0, so that generators can add a post part if the parallel one does not contain suspendable actors