### PR TITLE
Adding sequential specification for verifiers

### DIFF
--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/LinChecker.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/LinChecker.java
@@ -26,9 +26,7 @@ import org.jetbrains.kotlinx.lincheck.annotations.LogLevel;
 import org.jetbrains.kotlinx.lincheck.execution.*;
 import org.jetbrains.kotlinx.lincheck.strategy.Strategy;
 import org.jetbrains.kotlinx.lincheck.verifier.*;
-import org.jetbrains.kotlinx.lincheck.verifier.quantitative.QuantitativeRelaxationVerifierConf;
 import static org.jetbrains.kotlinx.lincheck.ReporterKt.DEFAULT_LOG_LEVEL;
-import static org.jetbrains.kotlinx.lincheck.UtilsKt.createTestInstance;
 import java.util.*;
 
 
@@ -48,7 +46,7 @@ public class LinChecker {
         LoggingLevel logLevel;
         if (options != null) {
             logLevel = options.logLevel;
-            this.testConfigurations = Collections.singletonList(options.createTestConfigurations());
+            this.testConfigurations = Collections.singletonList(options.createTestConfigurations(testClass));
         } else {
             logLevel = getLogLevelFromAnnotation();
             this.testConfigurations = CTestConfiguration.createFromTestClass(testClass);
@@ -95,7 +93,6 @@ public class LinChecker {
     }
 
     private void checkImpl(CTestConfiguration testCfg) throws AssertionError, Exception {
-        if (testCfg.requireStateEquivalenceImplCheck) checkStateEquivalenceImpl(testClass);
         ExecutionGenerator exGen = createExecutionGenerator(testCfg.generatorClass, testCfg);
         // Run iterations
         for (int iteration = 1; iteration <= testCfg.iterations; iteration++) {
@@ -165,23 +162,10 @@ public class LinChecker {
 
     private void runScenario(ExecutionScenario scenario, CTestConfiguration testCfg) throws AssertionError, Exception {
         validateScenario(testCfg, scenario);
-        Verifier verifier = createVerifier(testCfg.verifierClass, scenario, testClass);
+        Verifier verifier = createVerifier(testCfg.verifierClass, scenario, testCfg.sequentialSpecification);
+        if (testCfg.requireStateEquivalenceImplCheck) verifier.checkStateEquivalenceImplementation();
         Strategy strategy = Strategy.createStrategy(testCfg, testClass, scenario, verifier, reporter);
         strategy.run();
-    }
-
-    private void checkStateEquivalenceImpl(Class<?> testClass) {
-        if (!testClass.isAnnotationPresent(QuantitativeRelaxationVerifierConf.class)) {
-            Object i1 = createTestInstance(testClass);
-            Object i2 = createTestInstance(testClass);
-            if (i1.hashCode() != i2.hashCode() || !i1.equals(i2)) {
-                throw new IllegalStateException(
-                    "equals() and hashCode() methods for this test are not defined or defined incorrectly.\n" +
-                    "It is more convenient to make the test class extend `VerifierState` class and override `extractState()` function to define equals() and hashCode() methods.\n" +
-                    "This check may be suppressed by setting the requireStateEquivalenceImplementationCheck option to false."
-                );
-            }
-        }
     }
 
     private void validateScenario(CTestConfiguration testCfg, ExecutionScenario scenario) {
@@ -194,15 +178,13 @@ public class LinChecker {
     }
 
     private Verifier createVerifier(Class<? extends Verifier> verifierClass, ExecutionScenario scenario,
-                                    Class<?> testClass) throws Exception {
-        return verifierClass.getConstructor(ExecutionScenario.class, Class.class)
-                .newInstance(scenario, testClass);
+                                    Class<?> sequentialSpecification) throws Exception {
+        return verifierClass.getConstructor(ExecutionScenario.class, Class.class).newInstance(scenario, sequentialSpecification);
     }
 
     private ExecutionGenerator createExecutionGenerator(Class<? extends ExecutionGenerator> generatorClass,
                                                         CTestConfiguration testConfiguration) throws Exception {
-        return generatorClass.getConstructor(CTestConfiguration.class, CTestStructure.class)
-                .newInstance(testConfiguration, testStructure);
+        return generatorClass.getConstructor(CTestConfiguration.class, CTestStructure.class).newInstance(testConfiguration, testStructure);
     }
 
     private LoggingLevel getLogLevelFromAnnotation() {

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/Options.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/Options.java
@@ -26,6 +26,7 @@ import org.jetbrains.kotlinx.lincheck.annotations.Operation;
 import org.jetbrains.kotlinx.lincheck.execution.ExecutionGenerator;
 import org.jetbrains.kotlinx.lincheck.execution.ExecutionScenario;
 import org.jetbrains.kotlinx.lincheck.verifier.Verifier;
+import org.jetbrains.kotlinx.lincheck.verifier.quantitative.QuantitativelyRelaxedLinearizabilityVerifier;
 
 import static org.jetbrains.kotlinx.lincheck.ReporterKt.DEFAULT_LOG_LEVEL;
 
@@ -43,6 +44,7 @@ public abstract class Options<OPT extends Options, CTEST extends CTestConfigurat
     protected Class<? extends Verifier> verifier = CTestConfiguration.DEFAULT_VERIFIER;
     protected boolean requireStateEquivalenceImplementationCheck = true;
     protected boolean minimizeFailedScenario = CTestConfiguration.DEFAULT_MINIMIZE_ERROR;
+    protected Class<?> sequentialSpecification = null;
 
     /**
      * Number of different test scenarios to be executed
@@ -141,7 +143,7 @@ public abstract class Options<OPT extends Options, CTEST extends CTestConfigurat
         return (OPT) this;
     }
 
-    public abstract CTEST createTestConfigurations();
+    public abstract CTEST createTestConfigurations(Class<?> testClass);
 
     /**
      * Set logging level, {@link DEFAULT_LOG_LEVEL} is used by default.
@@ -150,4 +152,20 @@ public abstract class Options<OPT extends Options, CTEST extends CTestConfigurat
         this.logLevel = logLevel;
         return (OPT) this;
     }
+
+
+    /**
+     * The specified class defines the sequential behavior of the testing data structure;
+     * it is used by {@link Verifier} to build a labeled transition system,
+     * and should have the same methods as the testing data structure.
+     * However, some verifiers require additional parameters for these methods,
+     * see {@link QuantitativelyRelaxedLinearizabilityVerifier} as an example.
+     *
+     * By default, the provided concurrent implementation is used in a sequential way.
+     */
+    public OPT sequentialSpecification(Class<?> clazz) {
+        this.sequentialSpecification = clazz;
+        return (OPT) this;
+    }
+
 }

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
@@ -104,7 +104,7 @@ open class ParallelThreadsRunner(
     private fun isThreadCompleted(threadId: Int, actorId: Int) = actorId == scenario.parallelExecution[threadId].size - 1
 
     private fun reset() {
-        testInstance = createTestInstance(testClass)
+        testInstance = testClass.newInstance()
         testThreadExecutions.forEach { ex -> ex.testInstance = testInstance }
         suspensionPointResults = MutableList(scenario.threads) { NoResult }
         completedOrSuspendedThreads.set(0)

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/randomswitch/RandomSwitchCTest.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/randomswitch/RandomSwitchCTest.java
@@ -27,8 +27,10 @@ import org.jetbrains.kotlinx.lincheck.annotations.Operation;
 import org.jetbrains.kotlinx.lincheck.execution.ExecutionGenerator;
 import org.jetbrains.kotlinx.lincheck.execution.ExecutionScenario;
 import org.jetbrains.kotlinx.lincheck.execution.RandomExecutionGenerator;
+import org.jetbrains.kotlinx.lincheck.verifier.DummySequentialSpecification;
 import org.jetbrains.kotlinx.lincheck.verifier.linearizability.LinearizabilityVerifier;
 import org.jetbrains.kotlinx.lincheck.verifier.Verifier;
+import org.jetbrains.kotlinx.lincheck.verifier.quantitative.QuantitativelyRelaxedLinearizabilityVerifier;
 
 import java.lang.annotation.*;
 
@@ -114,6 +116,17 @@ public @interface RandomSwitchCTest {
      * Enabled by default.
      */
     boolean minimizeFailedScenario() default true;
+
+    /**
+     * The specified class defines the sequential behavior of the testing data structure;
+     * it is used by {@link Verifier} to build a labeled transition system,
+     * and should have the same methods as the testing data structure.
+     * However, some verifiers require additional parameters for these methods,
+     * see {@link QuantitativelyRelaxedLinearizabilityVerifier} as an example.
+     *
+     * By default, the provided concurrent implementation is used in a sequential way.
+     */
+    Class<?> sequentialSpecification() default DummySequentialSpecification.class;
 
     /**
      * Holder annotation for {@link RandomSwitchCTest}.

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/randomswitch/RandomSwitchCTestConfiguration.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/randomswitch/RandomSwitchCTestConfiguration.java
@@ -33,12 +33,13 @@ public class RandomSwitchCTestConfiguration extends CTestConfiguration {
     public static final int DEFAULT_INVOCATIONS = 1_000;
     public final int invocationsPerIteration;
 
-    public RandomSwitchCTestConfiguration(int iterations, int threads, int actorsPerThread, int actorsBefore,
+    public RandomSwitchCTestConfiguration(Class<?> testClass, int iterations, int threads, int actorsPerThread, int actorsBefore,
         int actorsAfter, Class<? extends ExecutionGenerator> generatorClass, Class<? extends Verifier> verifierClass,
-        int invocationsPerIteration, boolean requireStateEquivalenceCheck, boolean minimizeFailedScenario)
+        int invocationsPerIteration, boolean requireStateEquivalenceCheck, boolean minimizeFailedScenario,
+        Class<?> sequentialSpecification)
     {
-        super(iterations, threads, actorsPerThread, actorsBefore, actorsAfter, generatorClass, verifierClass,
-                requireStateEquivalenceCheck, minimizeFailedScenario);
+        super(testClass, iterations, threads, actorsPerThread, actorsBefore, actorsAfter, generatorClass, verifierClass,
+                requireStateEquivalenceCheck, minimizeFailedScenario, sequentialSpecification);
         this.invocationsPerIteration = invocationsPerIteration;
     }
 }

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/randomswitch/RandomSwitchOptions.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/randomswitch/RandomSwitchOptions.java
@@ -24,6 +24,8 @@ package org.jetbrains.kotlinx.lincheck.strategy.randomswitch;
 
 import org.jetbrains.kotlinx.lincheck.Options;
 
+import static org.jetbrains.kotlinx.lincheck.UtilsKt.chooseSequentialSpecification;
+
 /**
  * Options for {@link RandomSwitchStrategy random-switch} strategy.
  */
@@ -39,8 +41,9 @@ public class RandomSwitchOptions extends Options<RandomSwitchOptions, RandomSwit
     }
 
     @Override
-    public RandomSwitchCTestConfiguration createTestConfigurations() {
-        return new RandomSwitchCTestConfiguration(iterations, threads, actorsPerThread, actorsBefore, actorsAfter,
-            executionGenerator, verifier, invocationsPerIteration, requireStateEquivalenceImplementationCheck, minimizeFailedScenario);
+    public RandomSwitchCTestConfiguration createTestConfigurations(Class<?> testClass) {
+        return new RandomSwitchCTestConfiguration(testClass, iterations, threads, actorsPerThread, actorsBefore, actorsAfter,
+            executionGenerator, verifier, invocationsPerIteration, requireStateEquivalenceImplementationCheck, minimizeFailedScenario,
+            chooseSequentialSpecification(sequentialSpecification, testClass));
     }
 }

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTest.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTest.java
@@ -27,8 +27,10 @@ import org.jetbrains.kotlinx.lincheck.annotations.Operation;
 import org.jetbrains.kotlinx.lincheck.execution.ExecutionGenerator;
 import org.jetbrains.kotlinx.lincheck.execution.ExecutionScenario;
 import org.jetbrains.kotlinx.lincheck.execution.RandomExecutionGenerator;
+import org.jetbrains.kotlinx.lincheck.verifier.DummySequentialSpecification;
 import org.jetbrains.kotlinx.lincheck.verifier.linearizability.LinearizabilityVerifier;
 import org.jetbrains.kotlinx.lincheck.verifier.Verifier;
+import org.jetbrains.kotlinx.lincheck.verifier.quantitative.QuantitativelyRelaxedLinearizabilityVerifier;
 
 import java.lang.annotation.*;
 
@@ -114,6 +116,17 @@ public @interface StressCTest {
      * Enabled by default.
      */
     boolean minimizeFailedScenario() default true;
+
+    /**
+     * The specified class defines the sequential behavior of the testing data structure;
+     * it is used by {@link Verifier} to build a labeled transition system,
+     * and should have the same methods as the testing data structure.
+     * However, some verifiers require additional parameters for these methods,
+     * see {@link QuantitativelyRelaxedLinearizabilityVerifier} as an example.
+     *
+     * By default, the provided concurrent implementation is used in a sequential way.
+     */
+    Class<?> sequentialSpecification() default DummySequentialSpecification.class;
 
     /**
      * Holder annotation for {@link StressCTest}.

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTestConfiguration.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTestConfiguration.java
@@ -35,12 +35,13 @@ public class StressCTestConfiguration extends CTestConfiguration {
     public final int invocationsPerIteration;
     public final boolean addWaits;
 
-    public StressCTestConfiguration(int iterations, int threads, int actorsPerThread, int actorsBefore, int actorsAfter,
+    public StressCTestConfiguration(Class<?> testClass, int iterations, int threads, int actorsPerThread, int actorsBefore, int actorsAfter,
         Class<? extends ExecutionGenerator> generatorClass, Class<? extends Verifier> verifierClass,
-        int invocationsPerIteration, boolean addWaits, boolean requireStateEquivalenceCheck, boolean minimizeFailedScenario)
+        int invocationsPerIteration, boolean addWaits, boolean requireStateEquivalenceCheck, boolean minimizeFailedScenario,
+        Class<?> sequentialSpecification)
     {
-        super(iterations, threads, actorsPerThread, actorsBefore, actorsAfter, generatorClass, verifierClass,
-                requireStateEquivalenceCheck, minimizeFailedScenario);
+        super(testClass, iterations, threads, actorsPerThread, actorsBefore, actorsAfter, generatorClass, verifierClass,
+                requireStateEquivalenceCheck, minimizeFailedScenario, sequentialSpecification);
         this.invocationsPerIteration = invocationsPerIteration;
         this.addWaits = addWaits;
     }

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/stress/StressOptions.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/stress/StressOptions.java
@@ -24,6 +24,8 @@ package org.jetbrains.kotlinx.lincheck.strategy.stress;
 
 import org.jetbrains.kotlinx.lincheck.Options;
 
+import static org.jetbrains.kotlinx.lincheck.UtilsKt.chooseSequentialSpecification;
+
 /**
  * Options for {@link StressStrategy stress} strategy.
  */
@@ -48,8 +50,9 @@ public class StressOptions extends Options<StressOptions, StressCTestConfigurati
     }
 
     @Override
-    public StressCTestConfiguration createTestConfigurations() {
-        return new StressCTestConfiguration(iterations, threads, actorsPerThread, actorsBefore, actorsAfter, executionGenerator,
-                verifier, invocationsPerIteration, addWaits, requireStateEquivalenceImplementationCheck, minimizeFailedScenario);
+    public StressCTestConfiguration createTestConfigurations(Class<?> testClass) {
+        return new StressCTestConfiguration(testClass, iterations, threads, actorsPerThread, actorsBefore, actorsAfter, executionGenerator,
+                verifier, invocationsPerIteration, addWaits, requireStateEquivalenceImplementationCheck, minimizeFailedScenario,
+                chooseSequentialSpecification(sequentialSpecification, testClass));
     }
 }

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/verifier/DummySequentialSpecification.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/verifier/DummySequentialSpecification.java
@@ -1,10 +1,8 @@
-package org.jetbrains.kotlinx.lincheck.verifier.quantitative;
-
-/*
+/*-
  * #%L
  * Lincheck
  * %%
- * Copyright (C) 2015 - 2018 Devexperts, LLC
+ * Copyright (C) 2019 JetBrains s.r.o.
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -21,25 +19,8 @@ package org.jetbrains.kotlinx.lincheck.verifier.quantitative;
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
+package org.jetbrains.kotlinx.lincheck.verifier;
 
-import org.jetbrains.kotlinx.lincheck.*;
-
-import java.lang.annotation.*;
-
-/**
- * Configuration for {@link QuantitativelyRelaxedLinearizabilityVerifier}
- * which should be added to a test class.
- */
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
-public @interface QuantitativeRelaxationVerifierConf {
-    /**
-     * Relaxation factor
-     */
-    int factor();
-
-    /**
-     * Path cost function
-     */
-    PathCostFunction pathCostFunc();
+public class DummySequentialSpecification {
+    private DummySequentialSpecification() {} // This dummy class should not be created
 }

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/verifier/EpsilonVerifier.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/verifier/EpsilonVerifier.java
@@ -30,10 +30,13 @@ import org.jetbrains.kotlinx.lincheck.execution.ExecutionScenario;
  */
 public class EpsilonVerifier implements Verifier {
 
-    public EpsilonVerifier(ExecutionScenario scenario, Class<?> testClass) {}
+    public EpsilonVerifier(ExecutionScenario scenario, Class<?> sequentialSpecification) {}
 
     @Override
     public boolean verifyResults(ExecutionResult results) {
         return true; // Always correct results :)
     }
+
+    @Override
+    public void checkStateEquivalenceImplementation() {}
 }

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/verifier/SerializabilityVerifier.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/verifier/SerializabilityVerifier.java
@@ -38,8 +38,8 @@ import java.util.stream.Collectors;
 public class SerializabilityVerifier extends CachedVerifier {
     private final LinearizabilityVerifier linearizabilityVerifier;
 
-    public SerializabilityVerifier(ExecutionScenario scenario, Class<?> testClass) {
-        this.linearizabilityVerifier = new LinearizabilityVerifier(convertScenario(scenario), testClass);
+    public SerializabilityVerifier(ExecutionScenario scenario, Class<?> sequentialSpecification) {
+        this.linearizabilityVerifier = new LinearizabilityVerifier(convertScenario(scenario), sequentialSpecification);
     }
 
     private static <T> List<List<T>> convert(List<T> initPart, List<List<T>> parallelPart, List<T> postPart) {
@@ -68,5 +68,10 @@ public class SerializabilityVerifier extends CachedVerifier {
     @Override
     public boolean verifyResultsImpl(ExecutionResult results) {
         return linearizabilityVerifier.verifyResultsImpl(convertResult(results));
+    }
+
+    @Override
+    public void checkStateEquivalenceImplementation() {
+        linearizabilityVerifier.checkStateEquivalenceImplementation();
     }
 }

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/verifier/Verifier.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/verifier/Verifier.java
@@ -30,7 +30,8 @@ import org.jetbrains.kotlinx.lincheck.verifier.linearizability.LinearizabilityVe
  * By default, it checks for linearizability (see {@link LinearizabilityVerifier}).
  * <p>
  * IMPORTANT!
- * All implementations should have {@code (ExecutionScenario scenario, Class<?> testClass)} constructor.
+ * All implementations should have {@code (ExecutionScenario scenario, Class<?> sequentialSpecification)} constructor,
+ * which takes the scenario to be tested and the correct sequential implementation of the testing data structure.
  */
 public interface Verifier {
     /**
@@ -38,4 +39,11 @@ public interface Verifier {
      * Returns {@code true} if results are possible, {@code false} otherwise.
      */
     boolean verifyResults(ExecutionResult results);
+
+    /**
+     * Verifiers which use sequential implementation instances as states (or parts of them)
+     * should check whether {@link #equals(Object)} and {@link #hashCode()} methods are implemented
+     * correctly.
+     */
+    void checkStateEquivalenceImplementation();
 }

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/verifier/linearizability/LinearizabilityVerifier.kt
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/verifier/linearizability/LinearizabilityVerifier.kt
@@ -40,12 +40,12 @@ import org.jetbrains.kotlinx.lincheck.verifier.quantitative.QuantitativelyRelaxe
  */
 class LinearizabilityVerifier(
     scenario: ExecutionScenario,
-    testClass: Class<*>
-) : AbstractLTSVerifier<LTS.State>(scenario, testClass) {
+    sequentialSpecification: Class<*>
+) : AbstractLTSVerifier<LTS.State>(scenario, sequentialSpecification) {
     private val relaxationFactor = 0
     private val pathCostFunc = PathCostFunction.NON_RELAXED
-    private val lts: LTS = LTS(
-        testClass = testClass,
+    override val lts: LTS = LTS(
+        sequentialSpecification = sequentialSpecification,
         isQuantitativelyRelaxed = false,
         relaxationFactor = 0
     )

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/verifier/quiescent/QuiescentConsistencyVerifier.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/verifier/quiescent/QuiescentConsistencyVerifier.java
@@ -36,9 +36,9 @@ public class QuiescentConsistencyVerifier extends CachedVerifier {
     private final ExecutionScenario originalScenario;
     private final LinearizabilityVerifier linearizabilityVerifier;
 
-    public QuiescentConsistencyVerifier(ExecutionScenario scenario, Class<?> testClass) {
+    public QuiescentConsistencyVerifier(ExecutionScenario scenario, Class<?> sequentialSpecification) {
         this.originalScenario = scenario;
-        this.linearizabilityVerifier = new LinearizabilityVerifier(convertScenario(scenario), testClass);
+        this.linearizabilityVerifier = new LinearizabilityVerifier(convertScenario(scenario), sequentialSpecification);
     }
 
     private static ExecutionScenario convertScenario(ExecutionScenario scenario) {
@@ -75,5 +75,10 @@ public class QuiescentConsistencyVerifier extends CachedVerifier {
             convertAccordingToScenario(originalScenario.parallelExecution, results.parallelResults),
             results.postResults)
         );
+    }
+
+    @Override
+    public void checkStateEquivalenceImplementation() {
+        linearizabilityVerifier.checkStateEquivalenceImplementation();
     }
 }

--- a/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/SequentialSpecificationTest.kt
+++ b/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/SequentialSpecificationTest.kt
@@ -1,0 +1,49 @@
+/*-
+ * #%L
+ * Lincheck
+ * %%
+ * Copyright (C) 2019 JetBrains s.r.o.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.jetbrains.kotlinx.lincheck.test.verifier
+
+import org.jetbrains.kotlinx.lincheck.LinChecker
+import org.jetbrains.kotlinx.lincheck.annotations.Operation
+import org.jetbrains.kotlinx.lincheck.strategy.stress.StressCTest
+import org.jetbrains.kotlinx.lincheck.verifier.VerifierState
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+@StressCTest(sequentialSpecification = CorrectCounter::class)
+class IncorrectCounter {
+    private var c = AtomicInteger()
+
+    @Operation
+    fun set(value: Int) = c.set(value)
+    @Operation
+    fun get() = c.get() + 1
+
+    @Test(expected = AssertionError::class)
+    fun test() = LinChecker.check(this::class.java)
+}
+
+class CorrectCounter: VerifierState() {
+    private var c = 0
+    fun set(value: Int) { c = value }
+    fun get(): Int = c
+    override fun extractState() = c
+}

--- a/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/quantitative/KPriorityQueueTest.kt
+++ b/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/quantitative/KPriorityQueueTest.kt
@@ -36,12 +36,9 @@ import org.jetbrains.kotlinx.lincheck.verifier.quantitative.QuantitativeRelaxati
 import org.jetbrains.kotlinx.lincheck.verifier.quantitative.QuantitativeRelaxed
 import org.junit.Test
 
-@StressCTest(verifier = QuantitativelyRelaxedLinearizabilityVerifier::class, threads = 2, actorsPerThread = 2, actorsAfter = 0, actorsBefore = 0)
-@QuantitativeRelaxationVerifierConf(
-    factor = 2,
-    pathCostFunc = PHI_INTERVAL_RESTRICTED_MAX,
-    costCounter = KPriorityQueueTest.CostCounter::class
-)
+@StressCTest(sequentialSpecification = KPriorityQueueTest.CostCounter::class,
+             verifier = QuantitativelyRelaxedLinearizabilityVerifier::class,
+             threads = 2, actorsPerThread = 2, actorsAfter = 0, actorsBefore = 0)
 @Param(name = "push-value", gen = IntGen::class, conf = "1:20")
 class KPriorityQueueTest {
     private val pq = KPriorityQueueSimulation(2)
@@ -56,6 +53,7 @@ class KPriorityQueueTest {
     @Test
     fun test() = LinChecker.check(KPriorityQueueTest::class.java)
 
+    @QuantitativeRelaxationVerifierConf(factor = 2, pathCostFunc = PHI_INTERVAL_RESTRICTED_MAX)
     data class CostCounter @JvmOverloads constructor(
         private val k: Int,
         private val pq: List<Int> = emptyList()

--- a/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/quantitative/KRelaxedPopStack.kt
+++ b/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/quantitative/KRelaxedPopStack.kt
@@ -25,9 +25,7 @@ package org.jetbrains.kotlinx.lincheck.test.verifier.quantitative
 import java.util.*
 
 class KRelaxedPopStack<T>(private val k: Int) {
-
     private val list = LinkedList<T>()
-
     private val random = Random()
 
     @Synchronized

--- a/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/quantitative/KStackTest.kt
+++ b/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/quantitative/KStackTest.kt
@@ -37,8 +37,7 @@ import java.lang.AssertionError
 
 private const val K = 2
 
-@StressCTest(verifier = QuantitativelyRelaxedLinearizabilityVerifier::class)
-@QuantitativeRelaxationVerifierConf(factor = K, pathCostFunc = MAX, costCounter = KStackRelaxedPushTest.CostCounter::class)
+@StressCTest(sequentialSpecification = KStackRelaxedPushTest.CostCounter::class, verifier = QuantitativelyRelaxedLinearizabilityVerifier::class)
 class KStackRelaxedPushTest {
     private val s = KStackSimulation<Int>(k = K)
 
@@ -52,8 +51,8 @@ class KStackRelaxedPushTest {
     @Test
     fun test() = LinChecker.check(KStackRelaxedPushTest::class.java)
 
-    // Should have '(k: Int)' constructor
-    data class CostCounter @JvmOverloads constructor(private val k: Int, private val s: List<Int> = emptyList()) {
+    @QuantitativeRelaxationVerifierConf(factor = K, pathCostFunc = MAX)
+    data class CostCounter @JvmOverloads constructor(private val k: Int, private val s: List<Int> = emptyList()) { // Should have '(k: Int)' constructor
         fun put(value: Int, result: Result): List<CostWithNextCostCounter<CostCounter>> {
             return (0..(k - 1).coerceAtMost(s.size)).map { i ->
                 val sNew = ArrayList(s)
@@ -75,9 +74,10 @@ class KStackRelaxedPushTest {
     }
 }
 
-@StressCTest(verifier = QuantitativelyRelaxedLinearizabilityVerifier::class, threads = 2, actorsPerThread = 6, invocationsPerIteration = 1000, iterations = 100)
+@StressCTest(sequentialSpecification = KStackRelaxedPopIncorrectTest.CostCounter::class,
+             verifier = QuantitativelyRelaxedLinearizabilityVerifier::class,
+             threads = 2, actorsPerThread = 6, invocationsPerIteration = 1000, iterations = 100)
 @LogLevel(LoggingLevel.DEBUG)
-@QuantitativeRelaxationVerifierConf(factor = K, pathCostFunc = MAX, costCounter = KStackRelaxedPopIncorrectTest.CostCounter::class)
 class KStackRelaxedPopIncorrectTest {
     private val s = KStackSimulation<Int>(k = K + 3)
 
@@ -91,8 +91,8 @@ class KStackRelaxedPopIncorrectTest {
     @Test(expected = AssertionError::class)
     fun test() = LinChecker.check(KStackRelaxedPopIncorrectTest::class.java)
 
-    // Should have '(k: Int)' constructor
-    data class CostCounter @JvmOverloads constructor(private val k: Int, private val s: List<Int> = emptyList()) {
+    @QuantitativeRelaxationVerifierConf(factor = K, pathCostFunc = MAX)
+    data class CostCounter @JvmOverloads constructor(private val k: Int, private val s: List<Int> = emptyList()) { // Should have '(k: Int)' constructor
         fun put(value: Int, result: Result): CostCounter {
             check(result is VoidResult)
             val sNew = ArrayList(s)
@@ -116,8 +116,7 @@ class KStackRelaxedPopIncorrectTest {
     }
 }
 
-@StressCTest(verifier = QuantitativelyRelaxedLinearizabilityVerifier::class)
-@QuantitativeRelaxationVerifierConf(factor = K, pathCostFunc = MAX, costCounter = KStackRelaxedPushAndPopTest.CostCounter::class)
+@StressCTest(sequentialSpecification = KStackRelaxedPushAndPopTest.CostCounter::class, verifier = QuantitativelyRelaxedLinearizabilityVerifier::class)
 class KStackRelaxedPushAndPopTest {
     private val s = KStackSimulation<Int>(k = K)
 
@@ -132,8 +131,8 @@ class KStackRelaxedPushAndPopTest {
     @Test
     fun test() = LinChecker.check(KStackRelaxedPushAndPopTest::class.java)
 
-    // Should have '(k: Int)' constructor
-    data class CostCounter @JvmOverloads constructor(private val k: Int, private val s: List<Int> = emptyList()) {
+    @QuantitativeRelaxationVerifierConf(factor = K, pathCostFunc = MAX)
+    data class CostCounter @JvmOverloads constructor(private val k: Int, private val s: List<Int> = emptyList()) { // Should have '(k: Int)' constructor
         fun put(value: Int, result: Result): List<CostWithNextCostCounter<CostCounter>> {
             return (0..(k - 1).coerceAtMost(s.size)).map { i ->
                 val sNew = ArrayList(s)

--- a/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/quantitative/QuantitativeStackTest.kt
+++ b/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/quantitative/QuantitativeStackTest.kt
@@ -33,12 +33,8 @@ import org.jetbrains.kotlinx.lincheck.verifier.quantitative.QuantitativelyRelaxe
 import org.jetbrains.kotlinx.lincheck.verifier.quantitative.*
 import org.junit.Test
 
-@StressCTest(verifier = QuantitativelyRelaxedLinearizabilityVerifier::class)
-@QuantitativeRelaxationVerifierConf(
-    factor = 3,
-    pathCostFunc = PathCostFunction.MAX,
-    costCounter = QuantitativeStackTest.CostCounter::class
-)
+@StressCTest(sequentialSpecification = QuantitativeStackTest.CostCounter::class,
+             verifier = QuantitativelyRelaxedLinearizabilityVerifier::class)
 @Param(name = "push", gen = IntGen::class, conf = "1:20")
 class QuantitativeStackTest {
     private val s = KRelaxedPopStack<Int>(2)
@@ -59,8 +55,8 @@ class QuantitativeStackTest {
     @Test
     fun test() = LinChecker.check(QuantitativeStackTest::class.java)
 
-    // Should have '(k: Int)' constructor
-    data class CostCounter @JvmOverloads constructor(
+    @QuantitativeRelaxationVerifierConf(factor = 3, pathCostFunc = PathCostFunction.MAX)
+    data class CostCounter @JvmOverloads constructor( // Should have '(k: Int)' constructor
         private val k: Int,
         private val s: List<Int> = emptyList()
     ) {

--- a/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/quantitative/StutteringCounterTest.java
+++ b/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/quantitative/StutteringCounterTest.java
@@ -22,9 +22,11 @@ package org.jetbrains.kotlinx.lincheck.test.verifier.quantitative;
  * #L%
  */
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.kotlinx.lincheck.*;
 import org.jetbrains.kotlinx.lincheck.annotations.*;
 import org.jetbrains.kotlinx.lincheck.strategy.stress.StressCTest;
+import org.jetbrains.kotlinx.lincheck.verifier.VerifierState;
 import org.jetbrains.kotlinx.lincheck.verifier.quantitative.QuantitativelyRelaxedLinearizabilityVerifier;
 import org.jetbrains.kotlinx.lincheck.verifier.quantitative.*;
 import org.junit.*;
@@ -32,10 +34,7 @@ import java.util.*;
 
 import static org.jetbrains.kotlinx.lincheck.verifier.quantitative.PathCostFunction.PHI_INTERVAL;
 
-@StressCTest(verifier = QuantitativelyRelaxedLinearizabilityVerifier.class)
-@Ignore
-@QuantitativeRelaxationVerifierConf(factor = 3, pathCostFunc = PHI_INTERVAL,
-    costCounter = StutteringCounterTest.CostCounter.class)
+@StressCTest(sequentialSpecification = StutteringCounterTest.CostCounter.class, verifier = QuantitativelyRelaxedLinearizabilityVerifier.class)
 public class StutteringCounterTest {
     private StutteringCounterSimulation counter = new StutteringCounterSimulation(3, 0.9f);
 
@@ -50,8 +49,9 @@ public class StutteringCounterTest {
         LinChecker.check(StutteringCounterTest.class);
     }
 
-    // Predicate: completedOrSuspendedThreads is not incremented
-    public static class CostCounter {
+    @QuantitativeRelaxationVerifierConf(factor = 3, pathCostFunc = PHI_INTERVAL)
+    public static class CostCounter extends VerifierState {
+        // Predicate: completedOrSuspendedThreads is not incremented
         private final int k;
         private final int value;
 
@@ -77,6 +77,12 @@ public class StutteringCounterTest {
                 // Only incremented or the same values are possible
                 return Collections.emptyList();
             }
+        }
+
+        @NotNull
+        @Override
+        protected Object extractState() {
+            return value;
         }
     }
 }


### PR DESCRIPTION
Instead of using concurrent implementations sequentially a sequential way as a specification, it is sometimes better to write a simple sequential implementation instead.