### PR TITLE
Make `Result` immutable

### DIFF
--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/verifier/linearizability/LinearizabilityVerifier.kt
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/verifier/linearizability/LinearizabilityVerifier.kt
@@ -51,7 +51,8 @@ class LinearizabilityVerifier(
     )
 
     override fun createInitialContext(results: ExecutionResult): VerifierContext<LTS.State> =
-        QuantitativelyRelaxedLinearizabilityContext(scenario, lts.initialState, results, relaxationFactor, pathCostFunc)
+        QuantitativelyRelaxedLinearizabilityContext(scenario, results, lts.initialState,
+            PathCostFunction.NON_RELAXED.createIterativePathCostFunctionCounter(0))
 }
 
 

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/verifier/quantitative/QuantitativelyRelaxedLinearizabilityVerifier.kt
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/verifier/quantitative/QuantitativelyRelaxedLinearizabilityVerifier.kt
@@ -82,7 +82,7 @@ class QuantitativelyRelaxedLinearizabilityVerifier(
     }
 
     override fun createInitialContext(results: ExecutionResult): VerifierContext<LTS.State> =
-        QuantitativelyRelaxedLinearizabilityContext(scenario, lts.initialState, results, relaxationFactor, pathCostFunc)
+        QuantitativelyRelaxedLinearizabilityContext(scenario, results, lts.initialState,  pathCostFunc.createIterativePathCostFunctionCounter(relaxationFactor))
 }
 
 

--- a/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/runner/ParallelThreadsRunnerEasyExceptionTest.kt
+++ b/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/runner/ParallelThreadsRunnerEasyExceptionTest.kt
@@ -106,7 +106,7 @@ class ParallelThreadsRunnerExceptionTest {
             parallel {
                 thread {
                     operation(
-                        actor(susWithoutException), ExceptionResult(SuspendResumeScenarios.TestException::class.java)
+                        actor(susWithoutException), ExceptionResult(SuspendResumeScenarios.TestException::class.java, wasSuspended = true)
                     )
                 }
                 thread {
@@ -126,7 +126,7 @@ class ParallelThreadsRunnerExceptionTest {
             parallel {
                 thread {
                     operation(
-                        actor(susResumeThrow), ExceptionResult(SuspendResumeScenarios.TestException::class.java)
+                        actor(susResumeThrow), ExceptionResult(SuspendResumeScenarios.TestException::class.java, wasSuspended = true)
                     )
                 }
                 thread {
@@ -134,8 +134,7 @@ class ParallelThreadsRunnerExceptionTest {
                 }
             }
         }
-        val runner =
-            ParallelThreadsRunner(scenario, mockStrategy, testClass, null)
+        val runner = ParallelThreadsRunner(scenario, mockStrategy, testClass, null)
         val results = runner.run()
         assertEquals(results, expectedResults)
     }

--- a/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/CustomScenarioDSL.kt
+++ b/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/CustomScenarioDSL.kt
@@ -61,7 +61,7 @@ fun verify(
     val verifier = verifierClass.getConstructor(ExecutionScenario::class.java, Class::class.java)
         .newInstance(scenario, testClass)
     val res = verifier.verifyResults(results)
-    if (expected) assert(res) else assert(!res)
+    assert(res == expected)
 }
 
 fun scenarioWithResults(

--- a/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/linearizability/BufferedChannelCustomTest.kt
+++ b/lincheck/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/linearizability/BufferedChannelCustomTest.kt
@@ -96,7 +96,7 @@ class BufferedChannelCustomTest : VerifierState() {
                     operation(actor(r), ValueResult(1))
                     operation(actor(r), ValueResult(2))
                     operation(actor(s,5), VoidResult)
-                    operation(actor(s,6), NoResult)
+                    operation(actor(s,6), Suspended)
                     operation(actor(r), NoResult)
                 }
             }
@@ -136,7 +136,7 @@ class BufferedChannelCustomTest : VerifierState() {
             post {
                 operation(actor(r), ValueResult(1))
                 operation(actor(r), ValueResult(2))
-                operation(actor(r), NoResult)
+                operation(actor(r), Suspended)
             }
         }, expected = true)
     }


### PR DESCRIPTION
`VoidResult` and `NoResult` were singletons with mutable `wasSuspended` parameter. Consequently, both LTS and runner changed this parameter to either `true` or `false` instead of creating immutable instances; this logic caused several bugs, which have been fixed in this pull request. The change makes `wasSuspended` final, and introduces the following singletons: `VoidResult`, `SuspendedVoidResult`, `NoResult`, `Suspended`.