### PR TITLE
Updated bytecode transformation dependencies

### DIFF
--- a/lincheck/pom.xml
+++ b/lincheck/pom.xml
@@ -13,13 +13,13 @@
     <dependencies>
         <dependency>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-all</artifactId>
-            <version>5.2</version>
+            <artifactId>asm-commons</artifactId>
+            <version>${asm.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.devexperts.jagent</groupId>
-            <artifactId>jagent-impl</artifactId>
-            <version>1.4</version>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-util</artifactId>
+            <version>${asm.version}</version>
         </dependency>
         <!--For tests-->
         <dependency>

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/runner/Runner.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/runner/Runner.java
@@ -27,14 +27,13 @@ import org.jetbrains.kotlinx.lincheck.TransformationClassLoader;
 import org.jetbrains.kotlinx.lincheck.execution.ExecutionResult;
 import org.jetbrains.kotlinx.lincheck.execution.ExecutionScenario;
 import org.jetbrains.kotlinx.lincheck.strategy.Strategy;
-import com.devexperts.jagent.ClassInfo;
 import org.objectweb.asm.ClassVisitor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Runner determines how to run your concurrent test. In order to support techniques
  * like fibers, it may require code transformation, so {@link #needsTransformation()}
- * method has to return {@code true} and {@link #createTransformer(ClassVisitor, ClassInfo)}
+ * method has to return {@code true} and {@link #createTransformer(ClassVisitor)}
  * one has to be implemented.
  */
 public abstract class Runner {
@@ -67,7 +66,7 @@ public abstract class Runner {
      *
      * @return class visitor which transform the code due to support this runner.
      */
-    public ClassVisitor createTransformer(ClassVisitor cv, ClassInfo classInfo) {
+    public ClassVisitor createTransformer(ClassVisitor cv) {
         throw new UnsupportedOperationException(getClass() + " runner does not transform classes");
     }
 

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/ManagedStrategy.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/ManagedStrategy.java
@@ -28,7 +28,6 @@ import org.jetbrains.kotlinx.lincheck.execution.ExecutionScenario;
 import org.jetbrains.kotlinx.lincheck.runner.ParallelThreadsRunner;
 import org.jetbrains.kotlinx.lincheck.runner.Runner;
 import org.jetbrains.kotlinx.lincheck.verifier.Verifier;
-import com.devexperts.jagent.ClassInfo;
 import org.objectweb.asm.ClassVisitor;
 
 /**
@@ -66,8 +65,8 @@ public abstract class ManagedStrategy extends Strategy {
     }
 
     @Override
-    public ClassVisitor createTransformer(ClassVisitor cv, ClassInfo classInfo) {
-        return transformer = new ManagedStrategyTransformer(cv, classInfo);
+    public ClassVisitor createTransformer(ClassVisitor cv) {
+        return transformer = new ManagedStrategyTransformer(cv);
     }
 
     @Override

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/ManagedStrategyTransformer.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/ManagedStrategyTransformer.java
@@ -23,7 +23,6 @@ package org.jetbrains.kotlinx.lincheck.strategy;
  */
 
 
-import com.devexperts.jagent.ClassInfo;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
@@ -56,17 +55,27 @@ class ManagedStrategyTransformer extends ClassVisitor {
     private static final Method AFTER_LOCK_RELEASE_METHOD = new Method("afterLockRelease", Type.VOID_TYPE, new Type[]{Type.INT_TYPE, Type.INT_TYPE, OBJECT_TYPE});
 
     private String className;
-    private String fileName;
+    private String fileName = "";
     private final List<StackTraceElement> codeLocations = new ArrayList<>();
 
-    public ManagedStrategyTransformer(ClassVisitor cv, ClassInfo ci) {
+    public ManagedStrategyTransformer(ClassVisitor cv) {
         super(ASM_API, cv);
-        this.className = ci.getClassName();
-        this.fileName = ci.getSourceFile();
     }
 
     public List<StackTraceElement> getCodeLocations() {
         return codeLocations;
+    }
+
+    @Override
+    public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+        this.className = name;
+        super.visit(version, access, name, signature, superName, interfaces);
+    }
+
+    @Override
+    public void visitSource(String source, String debug) {
+        this.fileName = source;
+        super.visitSource(source, debug);
     }
 
     @Override

--- a/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/Strategy.java
+++ b/lincheck/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/Strategy.java
@@ -31,7 +31,6 @@ import org.jetbrains.kotlinx.lincheck.strategy.randomswitch.RandomSwitchStrategy
 import org.jetbrains.kotlinx.lincheck.strategy.stress.StressCTestConfiguration;
 import org.jetbrains.kotlinx.lincheck.strategy.stress.StressStrategy;
 import org.jetbrains.kotlinx.lincheck.verifier.Verifier;
-import com.devexperts.jagent.ClassInfo;
 import org.objectweb.asm.ClassVisitor;
 
 import static org.jetbrains.kotlinx.lincheck.ReporterKt.appendIncorrectResults;
@@ -62,7 +61,7 @@ public abstract class Strategy {
         }
     }
 
-    public ClassVisitor createTransformer(ClassVisitor cv, ClassInfo classInfo) {
+    public ClassVisitor createTransformer(ClassVisitor cv) {
         throw new UnsupportedOperationException(getClass() + " runner does not transform classes");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <lastCopyrightYear>2019</lastCopyrightYear>
         <kotlin.version>1.3.41</kotlin.version>
         <dokka.version>0.9.17</dokka.version>
+        <asm.version>7.1</asm.version>
         <deploy.skip>false</deploy.skip>
     </properties>
 
@@ -255,13 +256,6 @@
         </dependency>
     </dependencies>
 
-    <repositories>
-        <repository>
-            <id>bintray-devexperts-Maven</id>
-            <name>bintray</name>
-            <url>https://dl.bintray.com/devexperts/Maven</url>
-        </repository>
-    </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>jcenter</id>


### PR DESCRIPTION
Changes:
1) Updated version of ASM to 7.1. Now LinCheck can transform classes up to Java 13.
2) Got rid of dependency from Devexperts Bintray  repository.