### PR TITLE
The obstruction-freedom check should ignore executions with uncompleted blocking operations

### DIFF
--- a/src/main/java/org/jetbrains/kotlinx/lincheck/Actor.kt
+++ b/src/main/java/org/jetbrains/kotlinx/lincheck/Actor.kt
@@ -37,6 +37,7 @@ data class Actor @JvmOverloads constructor(
     val handledExceptions: List<Class<out Throwable>>,
     val cancelOnSuspension: Boolean = false,
     val allowExtraSuspension: Boolean = false,
+    val blocking: Boolean = false,
     // we have to specify `isSuspendable` property explicitly for transformed classes since
     // `isSuspendable` implementation produces a circular dependency and, therefore, fails.
     val isSuspendable: Boolean = method.isSuspendable()

--- a/src/main/java/org/jetbrains/kotlinx/lincheck/CTestStructure.java
+++ b/src/main/java/org/jetbrains/kotlinx/lincheck/CTestStructure.java
@@ -99,10 +99,10 @@ public class CTestStructure {
         for (Method m : getDeclaredMethodSorted(clazz)) {
             // Operation
             if (m.isAnnotationPresent(Operation.class)) {
-                Operation operationAnn = m.getAnnotation(Operation.class);
+                Operation opAnn = m.getAnnotation(Operation.class);
                 boolean isSuspendableMethod = isSuspendable(m);
                 // Check that params() in @Operation is empty or has the same size as the method
-                if (operationAnn.params().length > 0 && operationAnn.params().length != m.getParameterCount()) {
+                if (opAnn.params().length > 0 && opAnn.params().length != m.getParameterCount()) {
                     throw new IllegalArgumentException("Invalid count of paramgen for " + m.toString()
                             + " method in @Operation");
                 }
@@ -110,16 +110,16 @@ public class CTestStructure {
                 final List<ParameterGenerator<?>> gens = new ArrayList<>();
                 int nParameters = m.getParameterCount() - (isSuspendableMethod ? 1 : 0);
                 for (int i = 0; i < nParameters; i++) {
-                    String nameInOperation = operationAnn.params().length > 0 ? operationAnn.params()[i] : null;
+                    String nameInOperation = opAnn.params().length > 0 ? opAnn.params()[i] : null;
                     gens.add(getOrCreateGenerator(m, m.getParameters()[i], nameInOperation, namedGens));
                 }
                 // Get list of handled exceptions if they are presented
-                List<Class<? extends Throwable>> handledExceptions = Arrays.asList(operationAnn.handleExceptionsAsResult());
-                ActorGenerator actorGenerator = new ActorGenerator(m, gens, handledExceptions, operationAnn.runOnce(),
-                    operationAnn.cancellableOnSuspension(), operationAnn.allowExtraSuspension());
+                List<Class<? extends Throwable>> handledExceptions = Arrays.asList(opAnn.handleExceptionsAsResult());
+                ActorGenerator actorGenerator = new ActorGenerator(m, gens, handledExceptions, opAnn.runOnce(),
+                    opAnn.cancellableOnSuspension(), opAnn.allowExtraSuspension(), opAnn.blocking());
                 actorGenerators.add(actorGenerator);
                 // Get list of groups and add this operation to specified ones
-                String opGroup = operationAnn.group();
+                String opGroup = opAnn.group();
                 if (!opGroup.isEmpty()) {
                     OperationGroup operationGroup = groupConfigs.get(opGroup);
                     if (operationGroup == null)

--- a/src/main/java/org/jetbrains/kotlinx/lincheck/Utils.kt
+++ b/src/main/java/org/jetbrains/kotlinx/lincheck/Utils.kt
@@ -221,7 +221,15 @@ internal fun ExecutionScenario.convertForLoader(loader: ClassLoader) = Execution
         actors.map { a ->
             val args = a.arguments.map { it.convertForLoader(loader) }
             // the original `isSuspendable` is used here since `KFunction.isSuspend` fails on transformed classes
-            Actor(a.method.convertForLoader(loader), args, a.handledExceptions, a.cancelOnSuspension, a.allowExtraSuspension, a.isSuspendable)
+            Actor(
+                method = a.method.convertForLoader(loader),
+                arguments = args,
+                handledExceptions = a.handledExceptions,
+                cancelOnSuspension = a.cancelOnSuspension,
+                allowExtraSuspension = a.allowExtraSuspension,
+                blocking = a.blocking,
+                isSuspendable = a.isSuspendable
+            )
         }
     },
     postExecution

--- a/src/main/java/org/jetbrains/kotlinx/lincheck/annotations/Operation.java
+++ b/src/main/java/org/jetbrains/kotlinx/lincheck/annotations/Operation.java
@@ -56,7 +56,7 @@ public @interface Operation {
     Class<? extends Throwable>[] handleExceptionsAsResult() default {};
 
     /**
-     * Specified whether the operation can be cancelled if it suspends,
+     * Specifies whether the operation can be cancelled if it suspends,
      * see {@link CancellableContinuation#cancel}; {@code true} by default.
      */
     boolean cancellableOnSuspension() default true;
@@ -69,4 +69,13 @@ public @interface Operation {
      * dual data structures formalism.
      */
     boolean allowExtraSuspension() default false;
+
+    /**
+     * Specifies whether this operation is blocking or may lead
+     * to a blocking behavior of another operation. This way,
+     * if the test checks for a non-blocking progress guarantee,
+     * <b>lincheck</b> will not fail the test if a hang is detected
+     * while one of the operations with this {@code blocking} marker is running.
+     */
+    boolean blocking() default false;
 }

--- a/src/main/java/org/jetbrains/kotlinx/lincheck/execution/ActorGenerator.kt
+++ b/src/main/java/org/jetbrains/kotlinx/lincheck/execution/ActorGenerator.kt
@@ -36,7 +36,8 @@ class ActorGenerator(
     private val handledExceptions: List<Class<out Throwable?>>,
     val useOnce: Boolean,
     cancellableOnSuspension: Boolean,
-    val allowExtraSuspension: Boolean
+    private val allowExtraSuspension: Boolean,
+    private val blocking: Boolean
 ) {
     private val cancellableOnSuspension = cancellableOnSuspension && isSuspendable
 
@@ -45,8 +46,14 @@ class ActorGenerator(
             .map { it.generate() }
             .map { if (it === THREAD_ID_TOKEN) threadId else it }
         val cancelOnSuspension = cancellableOnSuspension and DETERMINISTIC_RANDOM.nextBoolean()
-        return Actor(method, parameters, handledExceptions,
-                     cancelOnSuspension, allowExtraSuspension)
+        return Actor(
+            method = method,
+            arguments = parameters,
+            handledExceptions = handledExceptions,
+            cancelOnSuspension = cancelOnSuspension,
+            allowExtraSuspension = allowExtraSuspension,
+            blocking = blocking
+        )
     }
 
     val isSuspendable: Boolean get() = method.isSuspendable()

--- a/src/test/java/org/jetbrains/kotlinx/lincheck/test/BlockingOperationTest.kt
+++ b/src/test/java/org/jetbrains/kotlinx/lincheck/test/BlockingOperationTest.kt
@@ -1,3 +1,25 @@
+/*-
+ * #%L
+ * Lincheck
+ * %%
+ * Copyright (C) 2019 - 2020 JetBrains s.r.o.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 package org.jetbrains.kotlinx.lincheck.test
 
 import kotlinx.atomicfu.*

--- a/src/test/java/org/jetbrains/kotlinx/lincheck/test/BlockingOperationTest.kt
+++ b/src/test/java/org/jetbrains/kotlinx/lincheck/test/BlockingOperationTest.kt
@@ -1,0 +1,36 @@
+package org.jetbrains.kotlinx.lincheck.test
+
+import kotlinx.atomicfu.*
+import org.jetbrains.kotlinx.lincheck.*
+import org.jetbrains.kotlinx.lincheck.annotations.Operation
+import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
+import org.jetbrains.kotlinx.lincheck.verifier.*
+import org.junit.*
+
+class BlockingOperationTest {
+    private val counter = atomic(0)
+
+    @Operation
+    fun operation() {
+        while (counter.value % 2 != 0) {}
+    }
+
+    @Operation(blocking = true)
+    fun blocking(): Unit = synchronized(this) {}
+
+    @Operation(blocking = true)
+    fun leadsToBlocking() {
+        counter.incrementAndGet()
+        counter.incrementAndGet()
+    }
+
+    @Test
+    fun test() = ModelCheckingOptions()
+        .checkObstructionFreedom()
+        .verifier(EpsilonVerifier::class.java)
+        .requireStateEquivalenceImplCheck(false)
+        .minimizeFailedScenario(false)
+        .actorsBefore(0)
+        .actorsAfter(0)
+        .check(this::class)
+}

--- a/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/linearizability/ClocksTest.kt
+++ b/src/test/java/org/jetbrains/kotlinx/lincheck/test/verifier/linearizability/ClocksTest.kt
@@ -68,12 +68,12 @@ class ClocksTestScenarioGenerator(testCfg: CTestConfiguration, testStructure: CT
         emptyList(),
         listOf(
             listOf(
-                Actor(ClocksTest::a.javaMethod!!, emptyList(), emptyList(), false),
-                Actor(ClocksTest::b.javaMethod!!, emptyList(), emptyList(), false)
+                Actor(method = ClocksTest::a.javaMethod!!, arguments = emptyList(), handledExceptions = emptyList()),
+                Actor(method = ClocksTest::b.javaMethod!!, arguments = emptyList(), handledExceptions = emptyList())
             ),
             listOf(
-                Actor(ClocksTest::c.javaMethod!!, emptyList(), emptyList(), false),
-                Actor(ClocksTest::d.javaMethod!!, emptyList(), emptyList(), false)
+                Actor(method = ClocksTest::c.javaMethod!!, arguments = emptyList(), handledExceptions = emptyList()),
+                Actor(method = ClocksTest::d.javaMethod!!, arguments = emptyList(), handledExceptions = emptyList())
             )
         ),
         emptyList()


### PR DESCRIPTION
Sometimes some operations on the testing data structures are blocking, but it would be great to still be able to test the rest ones for obstruction-freedom.