### PR TITLE
Split blocking operations declaration

### DIFF
--- a/src/main/java/org/jetbrains/kotlinx/lincheck/Actor.kt
+++ b/src/main/java/org/jetbrains/kotlinx/lincheck/Actor.kt
@@ -38,6 +38,7 @@ data class Actor @JvmOverloads constructor(
     val cancelOnSuspension: Boolean = false,
     val allowExtraSuspension: Boolean = false,
     val blocking: Boolean = false,
+    val causesBlocking: Boolean = false,
     val promptCancellation: Boolean = false,
     // we have to specify `isSuspendable` property explicitly for transformed classes since
     // `isSuspendable` implementation produces a circular dependency and, therefore, fails.

--- a/src/main/java/org/jetbrains/kotlinx/lincheck/CTestStructure.java
+++ b/src/main/java/org/jetbrains/kotlinx/lincheck/CTestStructure.java
@@ -116,7 +116,8 @@ public class CTestStructure {
                 // Get list of handled exceptions if they are presented
                 List<Class<? extends Throwable>> handledExceptions = Arrays.asList(opAnn.handleExceptionsAsResult());
                 ActorGenerator actorGenerator = new ActorGenerator(m, gens, handledExceptions, opAnn.runOnce(),
-                    opAnn.cancellableOnSuspension(), opAnn.allowExtraSuspension(), opAnn.blocking(), opAnn.promptCancellation());
+                    opAnn.cancellableOnSuspension(), opAnn.allowExtraSuspension(), opAnn.blocking(), opAnn.causesBlocking(),
+                    opAnn.promptCancellation());
                 actorGenerators.add(actorGenerator);
                 // Get list of groups and add this operation to specified ones
                 String opGroup = opAnn.group();

--- a/src/main/java/org/jetbrains/kotlinx/lincheck/TransformationClassLoader.java
+++ b/src/main/java/org/jetbrains/kotlinx/lincheck/TransformationClassLoader.java
@@ -76,7 +76,6 @@ public class TransformationClassLoader extends ExecutionClassLoader {
     /**
      * Returns `true` if the specified class should not be transformed.
      */
-    @SuppressWarnings("KotlinInternalInJava")
     private static boolean doNotTransform(String className) {
         if (className.startsWith(REMAPPED_PACKAGE_CANONICAL_NAME)) return false;
         if (ManagedStrategyTransformerKt.isImpossibleToTransformApiClass(className)) return true;

--- a/src/main/java/org/jetbrains/kotlinx/lincheck/Utils.kt
+++ b/src/main/java/org/jetbrains/kotlinx/lincheck/Utils.kt
@@ -241,6 +241,7 @@ internal fun ExecutionScenario.convertForLoader(loader: ClassLoader) = Execution
                 cancelOnSuspension = a.cancelOnSuspension,
                 allowExtraSuspension = a.allowExtraSuspension,
                 blocking = a.blocking,
+                causesBlocking = a.causesBlocking,
                 promptCancellation = a.promptCancellation,
                 isSuspendable = a.isSuspendable
             )

--- a/src/main/java/org/jetbrains/kotlinx/lincheck/annotations/Operation.java
+++ b/src/main/java/org/jetbrains/kotlinx/lincheck/annotations/Operation.java
@@ -71,13 +71,23 @@ public @interface Operation {
     boolean allowExtraSuspension() default false;
 
     /**
-     * Specifies whether this operation is blocking or may lead
-     * to a blocking behavior of another operation. This way,
-     * if the test checks for a non-blocking progress guarantee,
-     * <b>lincheck</b> will not fail the test if a hang is detected
-     * while one of the operations with this {@code blocking} marker is running.
+     * Specifies whether this operation is blocking.
+     * This way, if the test checks for a non-blocking progress guarantee,
+     * <b>lincheck</b> will not fail the test if a hang is detected on
+     * a running operations with this {@code blocking} marker.
      */
     boolean blocking() default false;
+
+    /**
+     * Specifies whether this operation invocation can lead
+     * to a blocking behavior of another concurrent operation.
+     * This way, if the test checks for a non-blocking progress guarantee,
+     * <b>lincheck</b> will not fail the test if a hang is detected
+     * while one of the operations marked with {@link #causesBlocking}
+     * is running concurrently. Note, that this operation is not
+     * considered as blocking until it is marked as {@link #blocking}.
+     */
+    boolean causesBlocking() default false;
 
     /**
      * Specifies whether this cancellable operation supports

--- a/src/main/java/org/jetbrains/kotlinx/lincheck/execution/ActorGenerator.kt
+++ b/src/main/java/org/jetbrains/kotlinx/lincheck/execution/ActorGenerator.kt
@@ -38,6 +38,7 @@ class ActorGenerator(
     cancellableOnSuspension: Boolean,
     private val allowExtraSuspension: Boolean,
     private val blocking: Boolean,
+    private val causesBlocking: Boolean,
     promptCancellation: Boolean
 ) {
     private val cancellableOnSuspension = cancellableOnSuspension && isSuspendable
@@ -56,6 +57,7 @@ class ActorGenerator(
             cancelOnSuspension = cancelOnSuspension,
             allowExtraSuspension = allowExtraSuspension,
             blocking = blocking,
+            causesBlocking = causesBlocking,
             promptCancellation = promptCancellation
         )
     }

--- a/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedCTestConfiguration.kt
+++ b/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedCTestConfiguration.kt
@@ -44,8 +44,8 @@ abstract class ManagedCTestConfiguration(
         const val DEFAULT_INVOCATIONS = 10000
         const val DEFAULT_CHECK_OBSTRUCTION_FREEDOM = false
         const val DEFAULT_ELIMINATE_LOCAL_OBJECTS = true
-        const val DEFAULT_HANGING_DETECTION_THRESHOLD = 100
-        const val LIVELOCK_EVENTS_THRESHOLD = 10000
+        const val DEFAULT_HANGING_DETECTION_THRESHOLD = 101
+        const val LIVELOCK_EVENTS_THRESHOLD = 10001
         val DEFAULT_GUARANTEES = listOf( // These classes use WeakHashMap, and thus, their code is non-deterministic.
             // Non-determinism should not be present in managed executions, but luckily the classes
             // can be just ignored, so that no thread context switches are added inside their methods.

--- a/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/managed/TracePoint.kt
+++ b/src/main/java/org/jetbrains/kotlinx/lincheck/strategy/managed/TracePoint.kt
@@ -260,7 +260,8 @@ internal enum class SwitchReason(private val reason: String) {
  */
 internal class CallStackTraceElement(val call: MethodCallTracePoint, val identifier: Int)
 
-private val Class<out Any>?.isImmutableWithNiceToString get() = this in listOf(
+@Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+private val Class<out Any>?.isImmutableWithNiceToString get() = this?.canonicalName in listOf(
     java.lang.Integer::class.java,
     java.lang.Long::class.java,
     java.lang.Short::class.java,
@@ -271,5 +272,6 @@ private val Class<out Any>?.isImmutableWithNiceToString get() = this in listOf(
     java.lang.Boolean::class.java,
     java.lang.String::class.java,
     BigInteger::class.java,
-    BigDecimal::class.java
-)
+    BigDecimal::class.java,
+    kotlinx.coroutines.internal.Symbol::class.java
+).map { it.canonicalName }

--- a/src/test/java/org/jetbrains/kotlinx/lincheck/test/BlockingBehaviourTest.kt
+++ b/src/test/java/org/jetbrains/kotlinx/lincheck/test/BlockingBehaviourTest.kt
@@ -30,6 +30,20 @@ import org.jetbrains.kotlinx.lincheck.verifier.*
 import org.junit.*
 
 class BlockingOperationTest {
+    @Operation(blocking = true)
+    fun blocking(): Unit = synchronized(this) {}
+
+    @Test
+    fun test() = ModelCheckingOptions()
+        .checkObstructionFreedom()
+        .verifier(EpsilonVerifier::class.java)
+        .requireStateEquivalenceImplCheck(false)
+        .actorsBefore(0)
+        .actorsAfter(0)
+        .check(this::class)
+}
+
+class CausesBlockingOperationTest {
     private val counter = atomic(0)
 
     @Operation
@@ -37,11 +51,8 @@ class BlockingOperationTest {
         while (counter.value % 2 != 0) {}
     }
 
-    @Operation(blocking = true)
-    fun blocking(): Unit = synchronized(this) {}
-
-    @Operation(blocking = true)
-    fun leadsToBlocking() {
+    @Operation(causesBlocking = true)
+    fun causesBlocking() {
         counter.incrementAndGet()
         counter.incrementAndGet()
     }
@@ -51,7 +62,6 @@ class BlockingOperationTest {
         .checkObstructionFreedom()
         .verifier(EpsilonVerifier::class.java)
         .requireStateEquivalenceImplCheck(false)
-        .minimizeFailedScenario(false)
         .actorsBefore(0)
         .actorsAfter(0)
         .check(this::class)


### PR DESCRIPTION
Split the operations that are blocking by themselves and that cause blocking behavior of concurrent ones