### PR TITLE
Fixed illegal access with package-private methods in ThreadLocalRandom

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategyTransformer.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategyTransformer.kt
@@ -670,6 +670,7 @@ internal class ManagedStrategyTransformer(
                 adapter.pop() // pop parameter
                 loadRandom()
                 adapter.invokeVirtual(RANDOM_TYPE, NEXT_INT_METHOD)
+                return
             }
             adapter.visitMethodInsn(opcode, owner, name, desc, itf)
         }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/AbstractLincheckTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/AbstractLincheckTest.kt
@@ -50,15 +50,15 @@ abstract class AbstractLincheckTest(
 
     @Test(timeout = TIMEOUT)
     fun testWithStressStrategy(): Unit = StressOptions().run {
-        commonConfiguration()
         invocationsPerIteration(5_000)
+        commonConfiguration()
         runInternalTest()
     }
 
     @Test(timeout = TIMEOUT)
     fun testWithModelCheckingStrategy(): Unit = ModelCheckingOptions().run {
-        commonConfiguration()
         invocationsPerIteration(1_000)
+        commonConfiguration()
         runInternalTest()
     }
 

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/PromptCancellationTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/PromptCancellationTest.kt
@@ -57,7 +57,7 @@ abstract class AbstractPromptCancellationTest(
         threads(2)
         actorsPerThread(1)
         actorsAfter(0)
-        if (this is StressOptions) invocationsPerIteration(1_000_000)
+        if (this is StressOptions) invocationsPerIteration(200_000)
         requireStateEquivalenceImplCheck(false)
         sequentialSpecification?.let { sequentialSpecification(it.java) }
     }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/verifier/linearizability/ConcurrentHashMapTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/verifier/linearizability/ConcurrentHashMapTest.kt
@@ -21,8 +21,10 @@
  */
 package org.jetbrains.kotlinx.lincheck.test.verifier.linearizability
 
+import org.jetbrains.kotlinx.lincheck.*
 import org.jetbrains.kotlinx.lincheck.annotations.*
 import org.jetbrains.kotlinx.lincheck.paramgen.*
+import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
 import org.jetbrains.kotlinx.lincheck.test.*
 import java.util.concurrent.*
 
@@ -34,7 +36,16 @@ class ConcurrentHashMapTest : AbstractLincheckTest() {
     fun put(@Param(name = "key") key: Int, value: Int) = map.put(key, value)
 
     @Operation
-    operator fun get(@Param(name = "key") key: Int?): Int? = map[key]
+    operator fun get(@Param(name = "key") key: Int) = map[key]
+
+    @Operation
+    fun remove(@Param(name = "key") key: Int) = map.remove(key)
 
     override fun extractState(): Any = map
+
+    override fun <O : Options<O, *>> O.customize() {
+        // To obtain rare interleaving with `fullAddCount` method
+        if (this is ModelCheckingOptions)
+            invocationsPerIteration(10000)
+    }
 }


### PR DESCRIPTION
Some concurrent structures in `java.util.concurrent` use package-private static methods from `ThreadLocalRandom` that caused illegal access errors in Java 9+