### PR TITLE
More verbose trace for managed strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ Here is a test for a not thread-safe `HashMap` with the failed scenario and the 
 @StressCTest(minimizeFailedScenario = false)
 @Param(name = "key", gen = IntGen.class, conf = "1:5")
 public class HashMapLinearizabilityTest extends VerifierState {
-    private HashMap<Integer, Integer> map = new HashMap<>();
+    private final HashMap<Integer, Integer> map = new HashMap<>();
 
     @Operation
     public Integer put(@Param(name = "key") int key, int value) {
@@ -504,26 +504,28 @@ If `@ModelCheckingCTest` was used instead of `@StressCTest` with `minimizeScenar
 ```
 = Invalid execution results =
 Parallel part:
-| put(4, -4): null | put(-8, -8): null |
-Post part:
-[get(-8): null]
-= The execution that led to this result =
-= Parallel part execution: =
-| put(4, -4)                                                  |                      |
-|   table.READ: null at HashMap.putVal(HashMap.java:628)      |                      |
-|   table.READ: null at HashMap.resize(HashMap.java:678)      |                      |
-|   switch                                                    |                      |
-|                                                             | put(-8, -8): null    |
-|                                                             |   thread is finished |
-|   threshold.READ: 12 at HashMap.resize(HashMap.java:680)    |                      |
-|   threshold.WRITE(9) at HashMap.resize(HashMap.java:702)    |                      |
-|   table.WRITE(Node[]@1) at HashMap.resize(HashMap.java:705) |                      |
-|   READ: null at HashMap.putVal(HashMap.java:630)            |                      |
-|   WRITE(Node@1) at HashMap.putVal(HashMap.java:631)         |                      |
-|   modCount.READ: 1 at HashMap.putVal(HashMap.java:661)      |                      |
-|   modCount.WRITE(2) at HashMap.putVal(HashMap.java:661)     |                      |
-|   size.READ: 1 at HashMap.putVal(HashMap.java:662)          |                      |
-|   size.WRITE(2) at HashMap.putVal(HashMap.java:662)         |                      |
-|   threshold.READ: 9 at HashMap.putVal(HashMap.java:662)     |                      |
-|   result: null                                              |                      |
-|   thread is finished                                        |                      |```
+| put(5, -8): null | put(5, 4): null |
+= The following interleaving leads to the error =
+Parallel part trace:
+| put(5, -8)                                                           |                      |
+|   put(5,-8): null at HashMapTest.put(HashMapTest.java:40)            |                      |
+|     putVal(0,5,-8,false,true): null at HashMap.put(HashMap.java:607) |                      |
+|       table.READ: null at HashMap.putVal(HashMap.java:623)           |                      |
+|       resize(): Node[]@1 at HashMap.putVal(HashMap.java:624)         |                      |
+|         table.READ: null at HashMap.resize(HashMap.java:673)         |                      |
+|         threshold.READ: 0 at HashMap.resize(HashMap.java:675)        |                      |
+|         threshold.WRITE(12) at HashMap.resize(HashMap.java:697)      |                      |
+|         switch                                                       |                      |
+|                                                                      | put(5, 4): null      |
+|                                                                      |   thread is finished |
+|         table.WRITE(Node[]@1) at HashMap.resize(HashMap.java:700)    |                      |
+|       READ: null at HashMap.putVal(HashMap.java:625)                 |                      |
+|       WRITE(Node@1) at HashMap.putVal(HashMap.java:626)              |                      |
+|       modCount.READ: 1 at HashMap.putVal(HashMap.java:656)           |                      |
+|       modCount.WRITE(2) at HashMap.putVal(HashMap.java:656)          |                      |
+|       size.READ: 1 at HashMap.putVal(HashMap.java:657)               |                      |
+|       size.WRITE(2) at HashMap.putVal(HashMap.java:657)              |                      |
+|       threshold.READ: 9 at HashMap.putVal(HashMap.java:657)          |                      |
+|   result: null                                                       |                      |
+|   thread is finished                                                 |                      |
+```

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestConfiguration.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlinx.lincheck.execution.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration.Companion.DEFAULT_ELIMINATE_LOCAL_OBJECTS
+import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration.Companion.DEFAULT_VERBOSE_TRACE
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
 import org.jetbrains.kotlinx.lincheck.strategy.stress.*
 import org.jetbrains.kotlinx.lincheck.verifier.*
@@ -81,7 +82,7 @@ internal fun createFromTestClassAnnotations(testClass: Class<*>): List<CTestConf
                 ann.generator.java, ann.verifier.java, ann.checkObstructionFreedom, ann.hangingDetectionThreshold,
                 ann.invocationsPerIteration, ManagedCTestConfiguration.DEFAULT_GUARANTEES, ann.requireStateEquivalenceImplCheck,
                 ann.minimizeFailedScenario, chooseSequentialSpecification(ann.sequentialSpecification.java, testClass),
-                DEFAULT_TIMEOUT_MS, DEFAULT_ELIMINATE_LOCAL_OBJECTS
+                DEFAULT_TIMEOUT_MS, DEFAULT_ELIMINATE_LOCAL_OBJECTS, DEFAULT_VERBOSE_TRACE
             )
         }
     return stressConfigurations + modelCheckingConfigurations

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/LincheckFailure.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/LincheckFailure.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlinx.lincheck.strategy.managed.*
 
 sealed class LincheckFailure(
     val scenario: ExecutionScenario,
-    val trace: List<TracePoint>?
+    val trace: Trace?
 ) {
     override fun toString() = StringBuilder().appendFailure(this).toString()
 }
@@ -36,35 +36,35 @@ sealed class LincheckFailure(
 internal class IncorrectResultsFailure(
     scenario: ExecutionScenario,
     val results: ExecutionResult,
-    trace: List<TracePoint>? = null
+    trace: Trace? = null
 ) : LincheckFailure(scenario, trace)
 
 internal class DeadlockWithDumpFailure(
     scenario: ExecutionScenario,
     val threadDump: Map<Thread, Array<StackTraceElement>>,
-    trace: List<TracePoint>? = null
+    trace: Trace? = null
 ) : LincheckFailure(scenario, trace)
 
 internal class UnexpectedExceptionFailure(
     scenario: ExecutionScenario,
     val exception: Throwable,
-    trace: List<TracePoint>? = null
+    trace: Trace? = null
 ) : LincheckFailure(scenario, trace)
 
 internal class ValidationFailure(
     scenario: ExecutionScenario,
     val functionName: String,
     val exception: Throwable,
-    trace: List<TracePoint>? = null
+    trace: Trace? = null
 ) : LincheckFailure(scenario, trace)
 
 internal class ObstructionFreedomViolationFailure(
     scenario: ExecutionScenario,
     val reason: String,
-    trace: List<TracePoint>? = null
+    trace: Trace? = null
 ) : LincheckFailure(scenario, trace)
 
-internal fun InvocationResult.toLincheckFailure(scenario: ExecutionScenario, trace: List<TracePoint>? = null) = when (this) {
+internal fun InvocationResult.toLincheckFailure(scenario: ExecutionScenario, trace: Trace? = null) = when (this) {
     is DeadlockInvocationResult -> DeadlockWithDumpFailure(scenario, threadDump, trace)
     is UnexpectedExceptionInvocationResult -> UnexpectedExceptionFailure(scenario, exception, trace)
     is ValidationFailureInvocationResult -> ValidationFailure(scenario, functionName, exception, trace)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedCTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedCTestConfiguration.kt
@@ -35,7 +35,7 @@ abstract class ManagedCTestConfiguration(
     generatorClass: Class<out ExecutionGenerator>, verifierClass: Class<out Verifier>,
     val checkObstructionFreedom: Boolean, val hangingDetectionThreshold: Int, val invocationsPerIteration: Int,
     val guarantees: List<ManagedStrategyGuarantee>, requireStateEquivalenceCheck: Boolean, minimizeFailedScenario: Boolean,
-    sequentialSpecification: Class<*>?, timeoutMs: Long, val eliminateLocalObjects: Boolean
+    sequentialSpecification: Class<*>?, timeoutMs: Long, val eliminateLocalObjects: Boolean, val verboseTrace: Boolean
 ) : CTestConfiguration(
     testClass, iterations, threads, actorsPerThread, actorsBefore, actorsAfter, generatorClass, verifierClass,
     requireStateEquivalenceCheck, minimizeFailedScenario, sequentialSpecification, timeoutMs
@@ -45,6 +45,7 @@ abstract class ManagedCTestConfiguration(
         const val DEFAULT_CHECK_OBSTRUCTION_FREEDOM = false
         const val DEFAULT_ELIMINATE_LOCAL_OBJECTS = true
         const val DEFAULT_HANGING_DETECTION_THRESHOLD = 101
+        const val DEFAULT_VERBOSE_TRACE = false
         const val LIVELOCK_EVENTS_THRESHOLD = 10001
         val DEFAULT_GUARANTEES = listOf( // These classes use WeakHashMap, and thus, their code is non-deterministic.
             // Non-determinism should not be present in managed executions, but luckily the classes

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedOptions.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedOptions.kt
@@ -79,9 +79,10 @@ abstract class ManagedOptions<OPT : Options<OPT, CTEST>, CTEST : CTestConfigurat
     }
 
     /**
-     * Set to `true` to make Lincheck log every execution event in an incorrect interleaving.
-     * By default, Lincheck will not report events in methods that do not have
-     * execution affecting events, such as context thread switches.
+     * Set to `true` to make Lincheck log all events in an incorrect execution trace.
+     * By default, Lincheck collapses the method invocations that were not interrupted
+     * (e.g., due to a switch to another thread), and omits all the details except for
+     * the method invocation result.
      */
     fun verboseTrace(verboseTrace: Boolean): OPT = applyAndCast {
         this.verboseTrace = verboseTrace

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedOptions.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedOptions.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration
 import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration.Companion.DEFAULT_GUARANTEES
 import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration.Companion.DEFAULT_HANGING_DETECTION_THRESHOLD
 import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration.Companion.DEFAULT_INVOCATIONS
+import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration.Companion.DEFAULT_VERBOSE_TRACE
 import java.util.*
 
 /**
@@ -38,6 +39,7 @@ abstract class ManagedOptions<OPT : Options<OPT, CTEST>, CTEST : CTestConfigurat
     protected var hangingDetectionThreshold = DEFAULT_HANGING_DETECTION_THRESHOLD
     protected val guarantees: MutableList<ManagedStrategyGuarantee> = ArrayList(DEFAULT_GUARANTEES)
     protected var eliminateLocalObjects: Boolean = DEFAULT_ELIMINATE_LOCAL_OBJECTS;
+    protected var verboseTrace = DEFAULT_VERBOSE_TRACE
 
     /**
      * Use the specified number of scenario invocations to study interleavings in each iteration.
@@ -74,6 +76,15 @@ abstract class ManagedOptions<OPT : Options<OPT, CTEST>, CTEST : CTestConfigurat
      */
     fun addGuarantee(guarantee: ManagedStrategyGuarantee): OPT = applyAndCast {
         guarantees.add(guarantee)
+    }
+
+    /**
+     * Set to `true` to make Lincheck log every execution event in an incorrect interleaving.
+     * By default, Lincheck will not report events in methods that do not have
+     * execution affecting events, such as context thread switches.
+     */
+    fun verboseTrace(verboseTrace: Boolean): OPT = applyAndCast {
+        this.verboseTrace = verboseTrace
     }
 
     /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -194,7 +194,7 @@ abstract class ManagedStrategy(
     /**
      * Re-runs the last invocation to collect its trace.
      */
-    private fun collectTrace(failingResult: InvocationResult): List<TracePoint>? {
+    private fun collectTrace(failingResult: InvocationResult): Trace? {
         val detectedByStrategy = suddenInvocationResult != null
         val canCollectTrace = when {
             detectedByStrategy -> true // ObstructionFreedomViolationInvocationResult or UnexpectedExceptionInvocationResult
@@ -226,7 +226,7 @@ abstract class ManagedStrategy(
                 appendln(loggedResults.asLincheckFailureWithoutTrace().toString())
             }.toString()
         }
-        return traceCollector!!.trace
+        return Trace(traceCollector!!.trace, testCfg.verboseTrace)
     }
 
     /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TracePoint.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TracePoint.kt
@@ -26,6 +26,8 @@ import java.util.*
 import kotlin.coroutines.*
 import kotlin.coroutines.intrinsics.*
 
+class Trace(val trace: List<TracePoint>, val verboseTrace: Boolean)
+
 /**
  * Essentially, a trace is a list of trace points, which represent
  * interleaving events, such as code location passing or thread switches,

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingCTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingCTestConfiguration.kt
@@ -34,10 +34,10 @@ class ModelCheckingCTestConfiguration(testClass: Class<*>, iterations: Int, thre
                                       actorsAfter: Int, generatorClass: Class<out ExecutionGenerator>, verifierClass: Class<out Verifier>,
                                       checkObstructionFreedom: Boolean, hangingDetectionThreshold: Int, invocationsPerIteration: Int,
                                       guarantees: List<ManagedStrategyGuarantee>, requireStateEquivalenceCheck: Boolean, minimizeFailedScenario: Boolean,
-                                      sequentialSpecification: Class<*>?, timeoutMs: Long, eliminateLocalObjects: Boolean
+                                      sequentialSpecification: Class<*>?, timeoutMs: Long, eliminateLocalObjects: Boolean, verboseTrace: Boolean
 ) : ManagedCTestConfiguration(testClass, iterations, threads, actorsPerThread, actorsBefore, actorsAfter, generatorClass, verifierClass,
     checkObstructionFreedom, hangingDetectionThreshold, invocationsPerIteration, guarantees, requireStateEquivalenceCheck,
-    minimizeFailedScenario, sequentialSpecification, timeoutMs, eliminateLocalObjects) {
+    minimizeFailedScenario, sequentialSpecification, timeoutMs, eliminateLocalObjects, verboseTrace) {
     override fun createStrategy(testClass: Class<*>, scenario: ExecutionScenario, validationFunctions: List<Method>,
                                 stateRepresentationMethod: Method?, verifier: Verifier): Strategy
         = ModelCheckingStrategy(this, testClass, scenario, validationFunctions, stateRepresentationMethod, verifier)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingOptions.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingOptions.kt
@@ -32,6 +32,6 @@ class ModelCheckingOptions : ManagedOptions<ModelCheckingOptions, ModelCheckingC
         return ModelCheckingCTestConfiguration(testClass, iterations, threads, actorsPerThread, actorsBefore, actorsAfter,
                 executionGenerator, verifier, checkObstructionFreedom, hangingDetectionThreshold, invocationsPerIteration,
                 guarantees, requireStateEquivalenceImplementationCheck, minimizeFailedScenario,
-                chooseSequentialSpecification(sequentialSpecification, testClass), timeoutMs, eliminateLocalObjects)
+                chooseSequentialSpecification(sequentialSpecification, testClass), timeoutMs, eliminateLocalObjects, verboseTrace)
     }
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/CapturedValueRepresentationTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/CapturedValueRepresentationTest.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlinx.lincheck.verifier.VerifierState
 import org.junit.Test
 
 /**
- * This test check that values captured in an incorrect interleaving have proper representation.
+ * This test checks that values captured in an incorrect interleaving have proper representation.
  * `toString` method is used only for primitive types and their wrappers.
  * For other classes we use simplified representation to avoid problems with concurrent modification or
  * not completely initialized objects (e.g, with `ConcurrentModificationException`)

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/MethodReportingTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/MethodReportingTest.kt
@@ -30,7 +30,7 @@ import org.junit.*
 import java.lang.StringBuilder
 
 /**
- * This test check interleaving reporting features related to methods, such as reporting of atomic functions with
+ * This test checks interleaving reporting features related to methods, such as reporting of atomic functions with
  * and their parameters and results compression of calls that are executed without a context switch in the middle.
  */
 class MethodReportingTest : VerifierState() {
@@ -87,10 +87,6 @@ class MethodReportingTest : VerifierState() {
         check("ignored" !in log) { "ignored methods should not be present in log" }
         check("nonPrimitiveParameter(IllegalStateException@1)" in log)
         check("nonPrimitiveResult(): IllegalStateException@2" in log)
-    }
-
-    private class BooleanHolder(var value: Boolean) {
-        override fun toString(): String = value.toString()
     }
 }
 

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/SwitchAsFirstMethodEventTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/SwitchAsFirstMethodEventTest.kt
@@ -1,59 +1,62 @@
-/*-
- * #%L
+/*
  * Lincheck
- * %%
+ *
  * Copyright (C) 2019 - 2020 JetBrains s.r.o.
- * %%
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-3.0.html>.
- * #L%
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>
  */
+
 package org.jetbrains.kotlinx.lincheck.test.representation
 
+import kotlinx.atomicfu.*
 import org.jetbrains.kotlinx.lincheck.*
-import org.jetbrains.kotlinx.lincheck.annotations.Operation
+import org.jetbrains.kotlinx.lincheck.annotations.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
-import org.jetbrains.kotlinx.lincheck.strategy.stress.*
-import org.jetbrains.kotlinx.lincheck.verifier.*
 import org.junit.*
-import java.util.concurrent.atomic.*
+import java.lang.StringBuilder
 
 /**
- * This test checks that AFU calls captured in an incorrect interleaving have proper representation.
- * Instead of `compareAndSet(object, 1, 2)` representation should be `fieldName.compareAndSet(1, 2)`,
- * where `fieldName` is the parameter in constructor for the AFU.
+ * This test checks that all switches that are the first events in methods are lifted out of the methods in the trace.
+ * E.g, instead of
+ * ```
+ * actor()
+ *   method()
+ *      switch
+ *      READ
+ *      ...
+ * ```
+ * should be
+ * ```
+ * actor()
+ *   switch
+ *   method()
+ *      ...
+ * ```
  */
-class AFUCallRepresentationTest : VerifierState() {
-    @Volatile
-    private var counter = 0
-    private val afu = AtomicIntegerFieldUpdater.newUpdater(AFUCallRepresentationTest::class.java, "counter")
+class SwitchAsFirstMethodEventTest {
+    private val counter = atomic(0)
 
     @Operation
-    fun operation(): Int {
-        var value = 0
-        // first inc
-        do {
-            value = afu.get(this)
-        } while (!afu.compareAndSet(this, value, value + 1))
-        // second inc
-        do {
-            value = afu.get(this)
-        } while (!afu.compareAndSet(this, value, value + 1))
-        return value + 1
+    fun incTwiceAndGet(): Int {
+        incAndGet()
+        return incAndGet()
     }
 
-    override fun extractState(): Any = counter
+    private fun incAndGet(): Int = incAndGetImpl()
+
+    private fun incAndGetImpl() = counter.incrementAndGet()
 
     @Test
     fun test() {
@@ -61,9 +64,16 @@ class AFUCallRepresentationTest : VerifierState() {
             .actorsPerThread(1)
             .actorsBefore(0)
             .actorsAfter(0)
+            .requireStateEquivalenceImplCheck(false)
         val failure = options.checkImpl(this::class.java)
         check(failure != null) { "the test should fail" }
         val log = StringBuilder().appendFailure(failure).toString()
-        check("counter.compareAndSet(0,1)" in log)
+        check(SwitchAsFirstMethodEventTest::incAndGet.name in log)
+        check(SwitchAsFirstMethodEventTest::incAndGetImpl.name !in log) {
+            "When the switch is lifted out of methods, there is no point at reporting this method"
+        }
+        check("incrementAndGet" !in log) {
+            "When the switch is lifted out of methods, there is no point at reporting this method"
+        }
     }
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/TraceReportingTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/TraceReportingTest.kt
@@ -27,7 +27,7 @@ import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
 import org.junit.*
 
 /**
- * This test check basic interleaving reporting features,
+ * This test checks basic interleaving reporting features,
  * including reporting of lock acquiring/releasing, reads/writes with parameter/result capturing.
  */
 class TraceReportingTest {

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/VerboseTraceTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/VerboseTraceTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2020 JetBrains s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>
+ */
+
+package org.jetbrains.kotlinx.lincheck.test.representation
+
+import org.jetbrains.kotlinx.lincheck.*
+import org.jetbrains.kotlinx.lincheck.annotations.*
+import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
+import org.junit.*
+
+/**
+ * This test checks `verboseTrace` option that makes Lincheck log all execution events.
+ */
+class VerboseTraceTest {
+    private var levelZeroCounter = 0
+    private var levelOneCounter = 0
+    private var levelTwoCounter = 0
+    private var counter = 0
+
+    @Operation
+    fun operation(): Int {
+        levelZeroCounter = 1
+        levelOneEvent()
+        return criticalSection()
+    }
+
+    private fun criticalSection(): Int = counter++
+
+    private fun levelOneEvent() {
+        levelTwoEvent()
+        levelOneCounter = 2
+    }
+
+    private fun levelTwoEvent() {
+        levelTwoCounter = 1
+    }
+
+    @Test
+    fun test() {
+        val failure = ModelCheckingOptions()
+            .actorsAfter(0)
+            .actorsBefore(0)
+            .actorsPerThread(1)
+            .requireStateEquivalenceImplCheck(false)
+            .verboseTrace(true)
+            .checkImpl(this::class.java)
+        checkNotNull(failure) { "test should fail" }
+        val log = failure.toString()
+        check("  criticalSection" in log) { "An intermediate method call was not logged or has an incorrect indentation" }
+        check("    counter.READ" in log)
+        check("  levelZeroCounter" in log)
+        check("  levelOneEvent" in log) { "An intermediate method call was not logged or has an incorrect indentation" }
+        check("    levelOneCounter" in log)
+        check("    levelTwoEvent" in log) { "An intermediate method call was not logged or has an incorrect indentation" }
+        check("      levelTwoCounter" in log)
+    }
+}


### PR DESCRIPTION
When `ModelCheckingOptions.verboseTrace` is set, Lincheck will not try to compress calls without thread context switches.

Moreover, this PR adds tree indentation to the trace, so instead of 
```
= Parallel part execution: =
| put(4, -4)                                                  |                      |
|   table.READ: null at HashMap.putVal(HashMap.java:628)      |                      |
|   table.READ: null at HashMap.resize(HashMap.java:678)      |                      |
|   switch                                                    |                      |
|                                                             | put(-8, -8): null    |
|                                                             |   thread is finished |
|   threshold.READ: 12 at HashMap.resize(HashMap.java:680)    |                      |
|   threshold.WRITE(9) at HashMap.resize(HashMap.java:702)    |                      |
|   table.WRITE(Node[]@1) at HashMap.resize(HashMap.java:705) |                      |
|   READ: null at HashMap.putVal(HashMap.java:630)            |                      |
|   WRITE(Node@1) at HashMap.putVal(HashMap.java:631)         |                      |
|   modCount.READ: 1 at HashMap.putVal(HashMap.java:661)      |                      |
|   modCount.WRITE(2) at HashMap.putVal(HashMap.java:661)     |                      |
|   size.READ: 1 at HashMap.putVal(HashMap.java:662)          |                      |
|   size.WRITE(2) at HashMap.putVal(HashMap.java:662)         |                      |
|   threshold.READ: 9 at HashMap.putVal(HashMap.java:662)     |                      |
|   result: null                                              |                      |
|   thread is finished                                        |                      |
```
the trace by default will look like
```
Parallel part trace:
| put(5, -8)                                                           |                      |
|   put(5,-8): null at HashMapTest.put(HashMapTest.java:40)            |                      |
|     putVal(0,5,-8,false,true): null at HashMap.put(HashMap.java:607) |                      |
|       table.READ: null at HashMap.putVal(HashMap.java:623)           |                      |
|       resize(): Node[]@1 at HashMap.putVal(HashMap.java:624)         |                      |
|         table.READ: null at HashMap.resize(HashMap.java:673)         |                      |
|         threshold.READ: 0 at HashMap.resize(HashMap.java:675)        |                      |
|         threshold.WRITE(12) at HashMap.resize(HashMap.java:697)      |                      |
|         switch                                                       |                      |
|                                                                      | put(5, 4): null      |
|                                                                      |   thread is finished |
|         table.WRITE(Node[]@1) at HashMap.resize(HashMap.java:700)    |                      |
|       READ: null at HashMap.putVal(HashMap.java:625)                 |                      |
|       WRITE(Node@1) at HashMap.putVal(HashMap.java:626)              |                      |
|       modCount.READ: 1 at HashMap.putVal(HashMap.java:656)           |                      |
|       modCount.WRITE(2) at HashMap.putVal(HashMap.java:656)          |                      |
|       size.READ: 1 at HashMap.putVal(HashMap.java:657)               |                      |
|       size.WRITE(2) at HashMap.putVal(HashMap.java:657)              |                      |
|       threshold.READ: 9 at HashMap.putVal(HashMap.java:657)          |                      |
|   result: null                                                       |                      |
|   thread is finished                                                 |                      |
```