### PR TITLE
Prompt cancellation should be emulated by cancelling the parent job

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
@@ -198,8 +198,7 @@ fun <T> CancellableContinuation<T>.cancelByLincheck(promptCancellation: Boolean)
         throw it.cause!! // let's throw the original exception, ignoring the internal coroutines details
     }
     if (!cancelled && promptCancellation) {
-        // TODO we can invoke the method directly if the transformation is disabled
-        getMethod(this, cancelCompletedResultMethod).invoke(this, null, cancellationByLincheckException)
+        context[Job]!!.cancel() // we should always put a job into the context for prompt cancellation
         return true
     }
     return cancelled

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/verifier/LTS.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/verifier/LTS.kt
@@ -393,7 +393,7 @@ internal class VerifierInterceptor(
 ) : AbstractCoroutineContextElement(ContinuationInterceptor),
     ContinuationInterceptor {
     override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> {
-        return Continuation(StoreExceptionHandler()) { res ->
+        return Continuation(StoreExceptionHandler() + Job()) { res ->
             // write the result only if the operation has not been cancelled
             if (!res.cancelledByLincheck()) {
                 resumedTicketsWithResults[ticket] = ResumedResult(continuation as Continuation<Any?> to res)
@@ -420,7 +420,7 @@ internal class Completion(
     private val resumedTicketsWithResults: MutableMap<Int, ResumedResult>
 ) : Continuation<Any?> {
     override val context: CoroutineContext
-        get() = VerifierInterceptor(ticket, actor, resumedTicketsWithResults) + StoreExceptionHandler()
+        get() = VerifierInterceptor(ticket, actor, resumedTicketsWithResults) + StoreExceptionHandler() + Job()
 
     override fun resumeWith(result: kotlin.Result<Any?>) {
         // write the result only if the operation has not been cancelled

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/PromptCancellationTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/PromptCancellationTest.kt
@@ -56,19 +56,20 @@ abstract class AbstractPromptCancellationTest(
     fun resumeOp(@Param(gen = IntGen::class, conf = "1:2") mode: Int): Int {
         val cont = cont ?: return -1
         when (mode) {
-            0 -> { // resume
+            1 -> { // resume
                 cont.resume(Unit) {
                     check(completedOrCancelled.compareAndSet(false, true))
                     returnResult = 42
                 }
             }
-            1 -> { // tryResume
+            2 -> { // tryResume
                 val token = cont.tryResume(Unit, null) {
                     check(completedOrCancelled.compareAndSet(false, true))
                     returnResult = 42
                 }
                 if (token != null) cont.completeResume(token)
             }
+            else -> error("Unexpected")
         }
         return returnResult
     }


### PR DESCRIPTION
Invoking `cancelCompletedResult` method is incorrect with `tryResume` -- it may lead to both completing the suspended coroutine and invoking all the cancellation handlers. See the unit test below that shows the problem:

```
@Test
fun testTryResumeOnCancellation() = runTest {
    // Start a new coroutine, suspend it, and store
    // the corresponding `CancellableContinuation` instance.
    var cont: CancellableContinuation<Unit>? = null
    launch {
        expect(2)
        suspendCancellableCoroutine<Unit> {
            cont = it
        }
        expectUnreached() // <-- IT IS REACHED ACTUALLY!!
    }
    expect(1)
    yield()
    expect(3)
    // Try to resume the launched coroutine.
    var onCancellationInvoked = false  // we expect it to become `true`
    val token = cont!!.tryResume(Unit, null) {
        onCancellationInvoked = true
    }
    assertNotNull(token) // assert that `tryResume` succeeded
    // Try to cancel the launched coroutine, should fail
    // due to the successful `tryResume` invocation.
    val cancelled = cont!!.cancel()
    assertFalse(cancelled)
    // However, `completeResume` has not been invoked yet,
    // so that the coroutine is not dispatched.
    // Let's then use prompt cancellation here.
    (cont as DispatchedTask<*>).cancelCompletedResult(null, Exception())
    // Complete the resumption. However, the coroutine should be cancelled due to
    // `cancelCompletedResult` invocation, so that `onCancellation` lambda should
    // be invoked and the coroutine execution should be aborted.
    cont!!.completeResume(token)
    assertTrue(onCancellationInvoked) // coroutine is cancelled while dispatching => should be invoked
    yield() // should not take any effect, but fails the test if the coroutine completes the execution
    finish(4)
}
```