### PR TITLE
Fix a big in wait/notify processing in model checking

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -224,8 +224,10 @@ abstract class ManagedStrategy(
         check(sameResultTypes && sameResults) {
             StringBuilder().apply {
                 appendln("Non-determinism found. Probably caused by non-deterministic code (WeakHashMap, Object.hashCode, etc).")
-                appendln("Reporting scenario without execution trace.")
-                appendln(loggedResults.asLincheckFailureWithoutTrace().toString())
+                appendln("== Reporting the first execution without execution trace ==")
+                appendln(failingResult.asLincheckFailureWithoutTrace())
+                appendln("== Reporting the second execution ==")
+                appendln(loggedResults.toLincheckFailure(scenario, Trace(traceCollector!!.trace, testCfg.verboseTrace)).toString())
             }.toString()
         }
         return Trace(traceCollector!!.trace, testCfg.verboseTrace)
@@ -447,7 +449,7 @@ abstract class ManagedStrategy(
      * @return whether lock should be actually acquired
      */
     internal fun beforeLockAcquire(iThread: Int, codeLocation: Int, tracePoint: MonitorEnterTracePoint?, monitor: Any): Boolean {
-        if (inIgnoredSection(iThread)) return true
+        if (!isTestThread(iThread)) return true
         newSwitchPoint(iThread, codeLocation, tracePoint)
         // Try to acquire the monitor
         if (!monitorTracker.acquireMonitor(iThread, monitor)) {
@@ -455,7 +457,7 @@ abstract class ManagedStrategy(
             // Switch to another thread and wait for a moment when the monitor can be acquired
             switchCurrentThread(iThread, SwitchReason.LOCK_WAIT, true)
             // Now it is possible to acquire the monitor, do it then.
-            monitorTracker.acquireMonitor(iThread, monitor)
+            require(monitorTracker.acquireMonitor(iThread, monitor))
         }
         // The monitor is acquired, finish.
         return false
@@ -499,7 +501,7 @@ abstract class ManagedStrategy(
      * @param iThread the number of the executed thread according to the [scenario][ExecutionScenario].
      * @param codeLocation the byte-code location identifier of this operation.
      * @param withTimeout `true` if is invoked with timeout, `false` otherwise.
-     * @return whether wait should be executed
+     * @return whether `Object.wait` should be executed
      */
     internal fun beforeWait(iThread: Int, codeLocation: Int, tracePoint: WaitTracePoint?, monitor: Any, withTimeout: Boolean): Boolean {
         if (!isTestThread(iThread)) return true
@@ -509,20 +511,23 @@ abstract class ManagedStrategy(
         monitorTracker.waitOnMonitor(iThread, monitor)
         // switch to another thread and wait till a notify event happens
         switchCurrentThread(iThread, SwitchReason.MONITOR_WAIT, true)
+        require(monitorTracker.acquireMonitor(iThread, monitor)) // acquire the lock again
         return false
     }
 
     /**
      * @param iThread the number of the executed thread according to the [scenario][ExecutionScenario].
      * @param codeLocation the byte-code location identifier of this operation.
+     * @return whether `Object.notify` should be executed
      */
-    internal fun afterNotify(iThread: Int, codeLocation: Int, tracePoint: NotifyTracePoint?, monitor: Any, notifyAll: Boolean) {
-        if (!isTestThread(iThread)) return
+    internal fun beforeNotify(iThread: Int, codeLocation: Int, tracePoint: NotifyTracePoint?, monitor: Any, notifyAll: Boolean): Boolean {
+        if (!isTestThread(iThread)) return true
         if (notifyAll)
             monitorTracker.notifyAll(monitor)
         else
             monitorTracker.notify(monitor)
         traceCollector?.passCodeLocation(tracePoint)
+        return false
     }
 
     /**

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/transformation/WaitNotifyLockTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/transformation/WaitNotifyLockTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2021 JetBrains s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>
+ */
+
+package org.jetbrains.kotlinx.lincheck.test.transformation
+
+import org.jetbrains.kotlinx.lincheck.LinChecker
+import org.jetbrains.kotlinx.lincheck.annotations.Operation
+import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingCTest
+import org.jetbrains.kotlinx.lincheck.verifier.VerifierState
+import org.junit.Test
+
+@ModelCheckingCTest(iterations = 30)
+class WaitNotifyLockTest : VerifierState() {
+    private var counter = 0
+    private val lock = WaitNotifyLock()
+
+    override fun extractState() = counter
+
+    @Operation
+    fun getAndIncrement() = lock.withLock { counter++ }
+
+    @Test
+    fun test() {
+        LinChecker.check(this::class.java)
+    }
+}
+
+private class WaitNotifyLock {
+    private var owner: Thread? = null
+
+    fun lock() {
+        val thread = Thread.currentThread()
+        synchronized(this) {
+            while (owner != null) {
+                (this as Object).wait()
+            }
+            owner = thread
+        }
+    }
+
+    fun unlock() {
+        synchronized(this) {
+            owner = null
+            (this as Object).notify()
+        }
+    }
+}
+
+private inline fun <T> WaitNotifyLock.withLock(body: () -> T): T {
+    try {
+        lock()
+        return body()
+    } finally {
+        unlock()
+    }
+}


### PR DESCRIPTION
Fixed several issues about `Object.wait()` and `Object.notify()` in the model checking mode.