### PR TITLE
Handle `null`-s as results properly 

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Result.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Result.kt
@@ -47,7 +47,7 @@ sealed class Result {
 class ValueResult @JvmOverloads constructor(val value: Any?, override val wasSuspended: Boolean = false) : Result() {
     private val valueClassTransformed: Boolean get() = value?.javaClass?.classLoader is TransformationClassLoader
     private val serializedObject: ByteArray by lazy(LazyThreadSafetyMode.NONE) {
-        check(value is Serializable) {
+        check(value is Serializable?) {
             "The result should either be a type always loaded by the system class loader " +
                 "(e.g., Int, String, List<T>) or implement Serializable interface; " +
                 "the actual class is ${value?.javaClass}."

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/transformation/SerializableValueTests.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/transformation/SerializableValueTests.kt
@@ -21,12 +21,13 @@
  */
 package org.jetbrains.kotlinx.lincheck.test.transformation
 
-import org.jetbrains.kotlinx.lincheck.Options
+import org.jetbrains.kotlinx.lincheck.*
 import org.jetbrains.kotlinx.lincheck.annotations.*
 import org.jetbrains.kotlinx.lincheck.paramgen.ParameterGenerator
 import org.jetbrains.kotlinx.lincheck.test.AbstractLincheckTest
+import org.junit.Assert.assertFalse
+import org.junit.Test
 import java.io.Serializable
-import java.util.*
 import java.util.concurrent.atomic.*
 
 class SerializableResultTest : AbstractLincheckTest() {
@@ -56,6 +57,20 @@ class SerializableJavaUtilResultTest : AbstractLincheckTest() {
         iterations(1)
         actorsBefore(0)
         actorsAfter(0)
+    }
+}
+
+class SerializableNullResultTest {
+    @Test
+    fun test() {
+        val a = ValueResult(null)
+        val value = ValueHolder(0)
+        val loader = TransformationClassLoader { CancellabilitySupportClassTransformer(it) }
+        val transformedValue = value.convertForLoader(loader)
+        val b = ValueResult(transformedValue)
+        // check that no exception was thrown
+        assertFalse(a == b)
+        assertFalse(b == a)
     }
 }
 
@@ -100,3 +115,21 @@ class JavaUtilGen(conf: String) : ParameterGenerator<List<Int>> {
 }
 
 class ValueHolder(val value: Int) : Serializable
+
+@Param(name = "key", gen = NullGen::class)
+class SerializableNullParameterTest : AbstractLincheckTest() {
+    @Operation
+    fun operation(@Param(name = "key") key: List<Int>?): Int = key?.sum() ?: 0
+
+    override fun extractState(): Any = 0 // constant state
+
+    override fun <O : Options<O, *>> O.customize() {
+        iterations(1)
+        actorsBefore(0)
+        actorsAfter(0)
+    }
+}
+
+class NullGen(conf: String) : ParameterGenerator<List<Int>?> {
+    override fun generate() = null
+}


### PR DESCRIPTION
Fixed a bug in handling `null` results