### PR TITLE
Single thread crash in MC

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/nvm/RecoverabilityModel.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/nvm/RecoverabilityModel.kt
@@ -114,6 +114,8 @@ interface RecoverabilityModel {
     fun createExecutionCallback(): ExecutionCallback
     fun createProbabilityModel(): ProbabilityModel
     val awaitSystemCrashBeforeThrow: Boolean
+
+    fun nonSystemCrashSupported() = systemCrashProbability() < 1.0
 }
 
 internal object NoRecoverModel : RecoverabilityModel {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -177,6 +177,8 @@ abstract class ManagedStrategy(
 
     protected abstract fun shouldCrash(iThread: Int): Boolean
 
+    protected abstract fun isSystemCrash(iThread: Int): Boolean
+
     /**
      * Choose a thread to switch from thread [iThread].
      * @return id the chosen thread
@@ -336,7 +338,7 @@ abstract class ManagedStrategy(
         val isSystemCrash = waitingSystemCrash()
         val shouldCrash = shouldCrash(iThread) || isSystemCrash
         if (shouldCrash) {
-            val initializeSystemCrash = !isSystemCrash && Probability.shouldSystemCrash()
+            val initializeSystemCrash = !isSystemCrash && isSystemCrash(iThread)
             if (initializeSystemCrash) {
                 systemCrashInitiator = iThread
             }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/verifier/nlr/ReadWriteObjectTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/verifier/nlr/ReadWriteObjectTest.kt
@@ -154,9 +154,6 @@ private fun actor(method: Method?, vararg a: Any?) = Actor(method!!, a.toMutable
 
 internal class ReadWriteObjectFailingTest1 : ReadWriteObjectFailingTest() {
     override val rwo = NRLFailingReadWriteObject1<Pair<Int, Int>>(THREADS_NUMBER + 2)
-    override fun ModelCheckingOptions.customize() {
-        actorsPerThread(2)
-    }
 }
 
 internal class ReadWriteObjectFailingTest2 : ReadWriteObjectFailingTest() {


### PR DESCRIPTION
NRL support single thread crashes. System/single-thread crash choice was done by random(which is deterministic in MC, so the whole iteration may be redundant). It is better to iterate over this choice in MC mode.

I had a falling test on bug search, which failed because of random single thread crash prioritising.
With this fix, bug search time has no visible changes.