### PR TITLE
Do not require state equivalance implementation by default

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestConfiguration.kt
@@ -47,7 +47,7 @@ abstract class CTestConfiguration(
     val verifierClass: Class<out Verifier>,
     val requireStateEquivalenceImplCheck: Boolean,
     val minimizeFailedScenario: Boolean,
-    val sequentialSpecification: Class<*>?,
+    val sequentialSpecification: Class<*>,
     val timeoutMs: Long
 ) {
     abstract fun createStrategy(testClass: Class<*>, scenario: ExecutionScenario, validationFunctions: List<Method>,

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/LinChecker.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/LinChecker.kt
@@ -168,7 +168,15 @@ class LinChecker (private val testClass: Class<*>, options: Options<*, *>?) {
 
     private fun CTestConfiguration.createVerifier() =
         verifierClass.getConstructor(Class::class.java).newInstance(sequentialSpecification).also {
-            if (requireStateEquivalenceImplCheck) it.checkStateEquivalenceImplementation()
+            val stateEquivalenceCorrect = it.checkStateEquivalenceImplementation()
+            if (!stateEquivalenceCorrect) {
+                if (requireStateEquivalenceImplCheck) {
+                    val errorMessage = StringBuilder().appendStateEquivalenceViolationMessage(sequentialSpecification).toString()
+                    error(errorMessage)
+                } else {
+                    reporter.logStateEquivalenceViolation(sequentialSpecification)
+                }
+            }
         }
 
     private fun CTestConfiguration.createExecutionGenerator() =

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Options.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Options.kt
@@ -37,7 +37,7 @@ abstract class Options<OPT : Options<OPT, CTEST>, CTEST : CTestConfiguration> {
     protected var actorsAfter = CTestConfiguration.DEFAULT_ACTORS_AFTER
     protected var executionGenerator = CTestConfiguration.DEFAULT_EXECUTION_GENERATOR
     protected var verifier = CTestConfiguration.DEFAULT_VERIFIER
-    protected var requireStateEquivalenceImplementationCheck = true
+    protected var requireStateEquivalenceImplementationCheck = false
     protected var minimizeFailedScenario = CTestConfiguration.DEFAULT_MINIMIZE_ERROR
     protected var sequentialSpecification: Class<*>? = null
     protected var timeoutMs: Long = CTestConfiguration.DEFAULT_TIMEOUT_MS

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Reporter.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Reporter.kt
@@ -29,7 +29,10 @@ import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.*
 import java.io.*
 
-class Reporter @JvmOverloads constructor(val logLevel: LoggingLevel, val out: PrintStream = System.out) {
+class Reporter constructor(val logLevel: LoggingLevel) {
+    private val out: PrintStream = System.out
+    private val outErr: PrintStream = System.err
+
     fun logIteration(iteration: Int, maxIterations: Int, scenario: ExecutionScenario) = log(INFO) {
         appendln("\n= Iteration $iteration / $maxIterations =")
         appendExecutionScenario(scenario)
@@ -44,17 +47,22 @@ class Reporter @JvmOverloads constructor(val logLevel: LoggingLevel, val out: Pr
         appendExecutionScenario(scenario)
     }
 
+    fun logStateEquivalenceViolation(sequentialSpecification: Class<*>) = log(WARN) {
+        appendStateEquivalenceViolationMessage(sequentialSpecification)
+    }
+
     private inline fun log(logLevel: LoggingLevel, crossinline msg: StringBuilder.() -> Unit): Unit = synchronized(this) {
         if (this.logLevel > logLevel) return
         val sb = StringBuilder()
         msg(sb)
-        out.println(sb)
+        val output = if (logLevel == WARN) outErr else out
+        output.println(sb)
     }
 }
 
-@JvmField val DEFAULT_LOG_LEVEL = ERROR
+@JvmField val DEFAULT_LOG_LEVEL = WARN
 enum class LoggingLevel {
-    INFO, ERROR
+    INFO, WARN
 }
 
 internal fun <T> printInColumnsCustom(
@@ -236,4 +244,12 @@ private fun StringBuilder.appendException(t: Throwable) {
     val sw = StringWriter()
     t.printStackTrace(PrintWriter(sw))
     appendln(sw.toString())
+}
+
+internal fun StringBuilder.appendStateEquivalenceViolationMessage(sequentialSpecification: Class<*>) {
+    append("To verify outcome results faster, it is highly recommended to specify the state equivalence relation on your" +
+        "sequential specification. However, on $sequentialSpecification it is is not defined or is implemented incorrectly. " +
+        "Please, specify the equivalence relation via implementing `equals()` and `hashCode()` functions on $sequentialSpecification. " +
+        "The most convenient way is to extend a special `VerifierState` class and override the `extractState()` function, which" +
+        "extracts and returns the logical state, which is used for further `equals()` and `hashCode()` calls.")
 }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/annotations/LogLevel.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/annotations/LogLevel.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation should be added to a test class to specify the logging level.
- * By default, {@link LoggingLevel#ERROR} is used.
+ * By default, {@link LoggingLevel#WARN} is used.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedCTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedCTestConfiguration.kt
@@ -35,7 +35,7 @@ abstract class ManagedCTestConfiguration(
     generatorClass: Class<out ExecutionGenerator>, verifierClass: Class<out Verifier>,
     val checkObstructionFreedom: Boolean, val hangingDetectionThreshold: Int, val invocationsPerIteration: Int,
     val guarantees: List<ManagedStrategyGuarantee>, requireStateEquivalenceCheck: Boolean, minimizeFailedScenario: Boolean,
-    sequentialSpecification: Class<*>?, timeoutMs: Long, val eliminateLocalObjects: Boolean, val verboseTrace: Boolean
+    sequentialSpecification: Class<*>, timeoutMs: Long, val eliminateLocalObjects: Boolean, val verboseTrace: Boolean
 ) : CTestConfiguration(
     testClass, iterations, threads, actorsPerThread, actorsBefore, actorsAfter, generatorClass, verifierClass,
     requireStateEquivalenceCheck, minimizeFailedScenario, sequentialSpecification, timeoutMs

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingCTest.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingCTest.java
@@ -117,7 +117,7 @@ public @interface ModelCheckingCTest {
      * Essentially, it checks whether two new instances of the test class are equal.
      * If the check fails, an {@link IllegalStateException} is thrown.
      */
-    boolean requireStateEquivalenceImplCheck() default true;
+    boolean requireStateEquivalenceImplCheck() default false;
 
     /**
      * If this feature is enabled and an invalid interleaving has been found,

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingCTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingCTestConfiguration.kt
@@ -34,7 +34,7 @@ class ModelCheckingCTestConfiguration(testClass: Class<*>, iterations: Int, thre
                                       actorsAfter: Int, generatorClass: Class<out ExecutionGenerator>, verifierClass: Class<out Verifier>,
                                       checkObstructionFreedom: Boolean, hangingDetectionThreshold: Int, invocationsPerIteration: Int,
                                       guarantees: List<ManagedStrategyGuarantee>, requireStateEquivalenceCheck: Boolean, minimizeFailedScenario: Boolean,
-                                      sequentialSpecification: Class<*>?, timeoutMs: Long, eliminateLocalObjects: Boolean, verboseTrace: Boolean
+                                      sequentialSpecification: Class<*>, timeoutMs: Long, eliminateLocalObjects: Boolean, verboseTrace: Boolean
 ) : ManagedCTestConfiguration(testClass, iterations, threads, actorsPerThread, actorsBefore, actorsAfter, generatorClass, verifierClass,
     checkObstructionFreedom, hangingDetectionThreshold, invocationsPerIteration, guarantees, requireStateEquivalenceCheck,
     minimizeFailedScenario, sequentialSpecification, timeoutMs, eliminateLocalObjects, verboseTrace) {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTest.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTest.java
@@ -106,7 +106,7 @@ public @interface StressCTest {
      * Essentially, it checks whether two new instances of the test class are equal.
      * If the check fails, an {@link IllegalStateException} is thrown.
      */
-    boolean requireStateEquivalenceImplCheck() default true;
+    boolean requireStateEquivalenceImplCheck() default false;
 
     /**
      * If this feature is enabled and an invalid interleaving has been found,

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTestConfiguration.kt
@@ -32,7 +32,7 @@ import java.lang.reflect.*
 class StressCTestConfiguration(testClass: Class<*>, iterations: Int, threads: Int, actorsPerThread: Int, actorsBefore: Int, actorsAfter: Int,
                                generatorClass: Class<out ExecutionGenerator>, verifierClass: Class<out Verifier>,
                                val invocationsPerIteration: Int, requireStateEquivalenceCheck: Boolean, minimizeFailedScenario: Boolean,
-                               sequentialSpecification: Class<*>?, timeoutMs: Long
+                               sequentialSpecification: Class<*>, timeoutMs: Long
 ) : CTestConfiguration(testClass, iterations, threads, actorsPerThread, actorsBefore, actorsAfter, generatorClass, verifierClass,
     requireStateEquivalenceCheck, minimizeFailedScenario, sequentialSpecification, timeoutMs) {
     override fun createStrategy(testClass: Class<*>, scenario: ExecutionScenario, validationFunctions: List<Method>,

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/verifier/EpsilonVerifier.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/verifier/EpsilonVerifier.java
@@ -36,5 +36,7 @@ public class EpsilonVerifier implements Verifier {
     }
 
     @Override
-    public void checkStateEquivalenceImplementation() {}
+    public boolean checkStateEquivalenceImplementation() {
+        return true;
+    }
 }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/verifier/LTS.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/verifier/LTS.kt
@@ -281,15 +281,10 @@ class LTS(sequentialSpecification: Class<*>) {
 
     private fun createInitialStateInstance() = sequentialSpecification.newInstance()
 
-    fun checkStateEquivalenceImplementation() {
+    fun checkStateEquivalenceImplementation(): Boolean {
         val i1 = createInitialStateInstance()
         val i2 = createInitialStateInstance()
-        check(i1.hashCode() == i2.hashCode() && i1 == i2) {
-            "equals() and hashCode() methods for this test are not defined or defined incorrectly.\n" +
-            "It is more convenient to make the sequential specification  class extend `VerifierState` class " +
-            "and override the `extractState()` function to define both equals() and hashCode() methods.\n" +
-            "This check may be suppressed by setting the `requireStateEquivalenceImplementationCheck` option to false."
-        }
+        return i1.hashCode() == i2.hashCode() && i1 == i2
     }
 
     private fun StateInfo.computeRemappingFunction(old: StateInfo): RemappingFunction? {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/verifier/SerializabilityVerifier.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/verifier/SerializabilityVerifier.kt
@@ -40,7 +40,8 @@ public class SerializabilityVerifier(
     override fun verifyResultsImpl(scenario: ExecutionScenario, results: ExecutionResult) =
         linerizabilityVerifier.verifyResultsImpl(scenario.converted, results.converted)
 
-    override fun checkStateEquivalenceImplementation() = linerizabilityVerifier.checkStateEquivalenceImplementation()
+    override fun checkStateEquivalenceImplementation(): Boolean =
+        linerizabilityVerifier.checkStateEquivalenceImplementation()
 
     private val ExecutionScenario.converted get() = ExecutionScenario(
         emptyList(), mergeAndFlatten(initExecution, parallelExecution, postExecution), emptyList()

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/verifier/Verifier.java
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/verifier/Verifier.java
@@ -41,9 +41,9 @@ public interface Verifier {
     boolean verifyResults(ExecutionScenario scenario, ExecutionResult results);
 
     /**
-     * Verifiers which use sequential implementation instances as states (or parts of them)
-     * should check whether {@link #equals(Object)} and {@link #hashCode()} methods are implemented
-     * correctly.
+     * Returns {@code true} when the state equivalence relation for the sequential specification
+     * is properly specified via {@link #equals(Object)} and {@link #hashCode()} methods. Returns
+     * `false` when two logically equal states do not satisfy the equals-hashCode contract.
      */
-    void checkStateEquivalenceImplementation();
+    boolean checkStateEquivalenceImplementation();
 }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/verifier/quiescent/QuiescentConsistencyVerifier.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/verifier/quiescent/QuiescentConsistencyVerifier.kt
@@ -39,7 +39,7 @@ class QuiescentConsistencyVerifier(sequentialSpecification: Class<*>) : Verifier
     private val linearizabilityVerifier = LinearizabilityVerifier(sequentialSpecification)
     private val scenarioMapping: MutableMap<ExecutionScenario, ExecutionScenario> = WeakHashMap()
 
-    override fun checkStateEquivalenceImplementation() = linearizabilityVerifier.checkStateEquivalenceImplementation()
+    override fun checkStateEquivalenceImplementation(): Boolean = linearizabilityVerifier.checkStateEquivalenceImplementation()
 
     override fun verifyResults(scenario: ExecutionScenario, results: ExecutionResult): Boolean {
         val convertedScenario = scenario.converted

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/StateEquivalenceImplCheckTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/StateEquivalenceImplCheckTest.kt
@@ -28,7 +28,7 @@ import org.junit.Test
 import java.lang.IllegalStateException
 import java.util.concurrent.atomic.AtomicInteger
 
-@StressCTest
+@StressCTest(requireStateEquivalenceImplCheck = true)
 class StateEquivalenceImplCheckTest {
     private var i = AtomicInteger(0)
 

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/strategy/modelchecking/ModelCheckingOptionsTest.java
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/strategy/modelchecking/ModelCheckingOptionsTest.java
@@ -53,7 +53,7 @@ public class ModelCheckingOptionsTest {
             .actorsPerThread(3)
             .checkObstructionFreedom(true)
             .hangingDetectionThreshold(30)
-            .logLevel(LoggingLevel.ERROR)
+            .logLevel(LoggingLevel.WARN)
             .addGuarantee(forClasses("java.util.WeakHashMap").allMethods().ignore())
             .requireStateEquivalenceImplCheck(false)
             .minimizeFailedScenario(false);

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/strategy/stress/StressOptionsTest.java
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/strategy/stress/StressOptionsTest.java
@@ -48,7 +48,7 @@ public class StressOptionsTest {
             .verifier(LinearizabilityVerifier.class)
             .threads(2)
             .actorsPerThread(3)
-            .logLevel(LoggingLevel.ERROR)
+            .logLevel(LoggingLevel.WARN)
             .requireStateEquivalenceImplCheck(false)
             .minimizeFailedScenario(false);
         LinChecker.check(StressOptionsTest.class, opts);


### PR DESCRIPTION
It is easier for newcomers when you do not need to specify equals/hashCode. Instead, we can print a warning message with an information how to improve the verification performance.