### PR TITLE
Fix LinCheck failing when state representation is non-deterministic

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/execution/ExecutionResult.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/execution/ExecutionResult.kt
@@ -60,6 +60,24 @@ data class ExecutionResult(
 ) {
     constructor(initResults: List<Result>, parallelResultsWithClock: List<List<ResultWithClock>>, postResults: List<Result>) :
         this(initResults, null, parallelResultsWithClock, null, postResults, null)
+
+    /**
+     * Override `equals` to ignore states.
+     * We do not require state generation to be deterministic, so
+     * states can differ for the same interleaving.
+     */
+    override fun equals(other: Any?): Boolean =
+        other is ExecutionResult &&
+        initResults == other.initResults &&
+        parallelResultsWithClock == other.parallelResultsWithClock &&
+        postResults == other.postResults
+
+    override fun hashCode(): Int {
+        var result = initResults.hashCode()
+        result = 31 * result + parallelResultsWithClock.hashCode()
+        result = 31 * result + postResults.hashCode()
+        return result
+    }
 }
 
 val ExecutionResult.withEmptyClocks: ExecutionResult get() = ExecutionResult(

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/LincheckFailure.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/LincheckFailure.kt
@@ -69,5 +69,6 @@ internal fun InvocationResult.toLincheckFailure(scenario: ExecutionScenario, tra
     is UnexpectedExceptionInvocationResult -> UnexpectedExceptionFailure(scenario, exception, trace)
     is ValidationFailureInvocationResult -> ValidationFailure(scenario, functionName, exception, trace)
     is ObstructionFreedomViolationInvocationResult -> ObstructionFreedomViolationFailure(scenario, reason, trace)
+    is CompletedInvocationResult -> IncorrectResultsFailure(scenario, results, trace)
     else -> error("Unexpected invocation result type: ${this.javaClass.simpleName}")
 }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -92,7 +92,7 @@ abstract class ManagedStrategy(
     private val tracePointConstructors: MutableList<TracePointConstructor> = ArrayList()
     // Collector of all events in the execution such as thread switches.
     private var traceCollector: TraceCollector? = null // null when `collectTrace` is false
-    // Stores the currently execuring methods call stack for each thread.
+    // Stores the currently executing methods call stack for each thread.
     private val callStackTrace = Array(nThreads) { mutableListOf<CallStackTraceElement>() }
     // Stores the global number of method calls.
     private var methodCallNumber = 0
@@ -225,7 +225,7 @@ abstract class ManagedStrategy(
             StringBuilder().apply {
                 appendln("Non-determinism found. Probably caused by non-deterministic code (WeakHashMap, Object.hashCode, etc).")
                 appendln("== Reporting the first execution without execution trace ==")
-                appendln(failingResult.asLincheckFailureWithoutTrace())
+                appendln(failingResult.toLincheckFailure(scenario, null))
                 appendln("== Reporting the second execution ==")
                 appendln(loggedResults.toLincheckFailure(scenario, Trace(traceCollector!!.trace, testCfg.verboseTrace)).toString())
             }.toString()
@@ -692,12 +692,6 @@ abstract class ManagedStrategy(
         } else {
             nThreads
         }
-    }
-
-    private fun InvocationResult.asLincheckFailureWithoutTrace(): LincheckFailure {
-        if (this is CompletedInvocationResult)
-            return IncorrectResultsFailure(scenario, results, null)
-        return toLincheckFailure(scenario, null)
     }
 
     /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TracePoint.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TracePoint.kt
@@ -235,6 +235,8 @@ internal class CoroutineCancellationTracePoint(
 
     override fun toStringImpl(): String {
         if (exception != null) return "EXCEPTION WHILE CANCELLATION"
+        // Do not throw exception when lateinit field is not initialized.
+        if (!::cancellationResult.isInitialized) return "<cancellation result not available>"
         return when (cancellationResult) {
             CANCELLED_BEFORE_RESUMPTION -> "CANCELLED BEFORE RESUMPTION"
             CANCELLED_AFTER_RESUMPTION -> "PROMPT CANCELLED AFTER RESUMPTION"


### PR DESCRIPTION
Execution results were also compared by states.
This is not correct, because we do not require state representations to be deterministic.
The bug showed only when there were incorrect results and non-deterministic state representation was defined.