### PR TITLE
Fix non-determinism due to not resetting TestThread.cont

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/FixedActiveThreadsExecutor.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/FixedActiveThreadsExecutor.kt
@@ -39,7 +39,7 @@ import kotlin.math.*
  */
 internal class FixedActiveThreadsExecutor(private val nThreads: Int, runnerHash: Int) : Closeable {
     // Threads used in this runner.
-    private val threads: List<TestThread>
+    val threads: List<TestThread>
     /**
      * null, waiting TestThread, Runnable task, or SHUTDOWN
      */

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
@@ -167,6 +167,8 @@ internal open class ParallelThreadsRunner(
         } else {
             spinningTimeBeforeYield = (spinningTimeBeforeYield * 2).coerceAtMost(MAX_SPINNING_TIME_BEFORE_YIELD)
         }
+        // reset stored continuations
+        executor.threads.forEach { it.cont = null }
     }
 
     /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -716,7 +716,8 @@ abstract class ManagedStrategy(
         }
 
         fun passCodeLocation(tracePoint: TracePoint?) {
-            _trace += tracePoint!!
+            // tracePoint can be null here if trace is not available, e.g. in case of suspension
+            if (tracePoint != null) _trace += tracePoint
         }
 
         fun addStateRepresentation(iThread: Int) {


### PR DESCRIPTION
By design, there can be thread switches in `Coroutine.cancel()` method.
However, this caused non-determinism due to not resetting `TestThread.cont` and, as a result, sometimes calling `TestThread.cont.cancel()` when there is no cancellable coroutine, adding odd switch points.