### PR TITLE
Fix equal objects having same representation number

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TraceReporter.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TraceReporter.kt
@@ -284,7 +284,7 @@ private class TraceEventRepresentation(val iThread: Int, val representation: Str
 
 // Should be called only during `appendTrace` invocation
 internal fun getObjectNumber(clazz: Class<Any>, obj: Any): Int = objectNumeration
-    .computeIfAbsent(clazz) { WeakHashMap() }
+    .computeIfAbsent(clazz) { IdentityHashMap() }
     .computeIfAbsent(obj) { 1 + objectNumeration[clazz]!!.size }
 
 private val objectNumeration = WeakHashMap<Class<Any>, MutableMap<Any, Int>>()

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/CapturedValueRepresentationTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/CapturedValueRepresentationTest.kt
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
@@ -36,7 +36,8 @@ import org.junit.Test
  */
 class CapturedValueRepresentationTest : VerifierState() {
     private var counter = 0
-    private var outerClass = OuterClass()
+    private var outerClass1 = OuterDataClass(0)
+    private var outerClass2 = OuterDataClass(0)
     private var innerClass = InnerClass()
     private var otherInnerClass = InnerClass()
     private var primitiveArray = IntArray(1)
@@ -44,7 +45,8 @@ class CapturedValueRepresentationTest : VerifierState() {
 
     @Operation
     fun operation(): Int {
-        outerClass
+        outerClass1
+        outerClass2
         innerClass
         innerClass
         otherInnerClass
@@ -62,13 +64,14 @@ class CapturedValueRepresentationTest : VerifierState() {
             .checkImpl(this::class.java)
         checkNotNull(failure) { "test should fail" }
         val log = failure.toString()
-        check(" OuterClass@1" in log)
+        check(" OuterDataClass@1" in log)
         check(" InnerClass@1" in log)
         check(log.split(" InnerClass@1").size - 1 == 2) { "two reads of innerClass should return same result" }
         check(" InnerClass@2" in log) { "Two different InnerClass objects were read, but the same was reported" }
         check(" int[]@1" in log)
         check(" String[]@1" in log)
         check(" 0" in log)
+        check(" OuterDataClass@2" in log) { "Equal but not same object should have different numbers" }
         checkTraceHasNoLincheckEvents(log)
     }
 
@@ -77,4 +80,4 @@ class CapturedValueRepresentationTest : VerifierState() {
     private class InnerClass
 }
 
-private class OuterClass
+private data class OuterDataClass(val a: Int)


### PR DESCRIPTION
Equal but not same object had the same representation.
For example,
```
field1 = emptyMap()
field2 = emptyMap()
```
was represented in trace as
```
field1.WRITE(HashMap@1)
field2.WRITE(HashMap@1)
```
but should be
```
field1.WRITE(HashMap@1)
field2.WRITE(HashMap@2)
```