### PR TITLE
Iteration skipping

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestConfiguration.kt
@@ -21,6 +21,7 @@
  */
 package org.jetbrains.kotlinx.lincheck
 
+import org.jetbrains.kotlinx.lincheck.CTestConfiguration.Companion.DEFAULT_SKIP_ITERATIONS
 import org.jetbrains.kotlinx.lincheck.CTestConfiguration.Companion.DEFAULT_TIMEOUT_MS
 import org.jetbrains.kotlinx.lincheck.execution.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
@@ -49,7 +50,8 @@ abstract class CTestConfiguration(
     val minimizeFailedScenario: Boolean,
     val sequentialSpecification: Class<*>,
     val timeoutMs: Long,
-    val customScenarios: List<ExecutionScenario>
+    val customScenarios: List<ExecutionScenario>,
+    val skipIterations: Int
 ) {
     abstract fun createStrategy(testClass: Class<*>, scenario: ExecutionScenario, validationFunctions: List<Method>,
                                 stateRepresentationMethod: Method?, verifier: Verifier): Strategy
@@ -63,6 +65,7 @@ abstract class CTestConfiguration(
         val DEFAULT_VERIFIER: Class<out Verifier> = LinearizabilityVerifier::class.java
         const val DEFAULT_MINIMIZE_ERROR = true
         const val DEFAULT_TIMEOUT_MS: Long = 10000
+        const val DEFAULT_SKIP_ITERATIONS = 0
     }
 }
 
@@ -74,7 +77,7 @@ internal fun createFromTestClassAnnotations(testClass: Class<*>): List<CTestConf
                 ann.generator.java, ann.verifier.java, ann.invocationsPerIteration,
                 ann.requireStateEquivalenceImplCheck, ann.minimizeFailedScenario,
                 chooseSequentialSpecification(ann.sequentialSpecification.java, testClass),
-                DEFAULT_TIMEOUT_MS, emptyList()
+                DEFAULT_TIMEOUT_MS, emptyList(), DEFAULT_SKIP_ITERATIONS
             )
         }
     val modelCheckingConfigurations: List<CTestConfiguration> = testClass.getAnnotationsByType(ModelCheckingCTest::class.java)
@@ -84,7 +87,7 @@ internal fun createFromTestClassAnnotations(testClass: Class<*>): List<CTestConf
                 ann.generator.java, ann.verifier.java, ann.checkObstructionFreedom, ann.hangingDetectionThreshold,
                 ann.invocationsPerIteration, ManagedCTestConfiguration.DEFAULT_GUARANTEES, ann.requireStateEquivalenceImplCheck,
                 ann.minimizeFailedScenario, chooseSequentialSpecification(ann.sequentialSpecification.java, testClass),
-                DEFAULT_TIMEOUT_MS, DEFAULT_ELIMINATE_LOCAL_OBJECTS, DEFAULT_VERBOSE_TRACE, emptyList()
+                DEFAULT_TIMEOUT_MS, DEFAULT_ELIMINATE_LOCAL_OBJECTS, DEFAULT_VERBOSE_TRACE, emptyList(), DEFAULT_SKIP_ITERATIONS
             )
         }
     return stressConfigurations + modelCheckingConfigurations

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Options.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Options.kt
@@ -42,6 +42,7 @@ abstract class Options<OPT : Options<OPT, CTEST>, CTEST : CTestConfiguration> {
     protected var sequentialSpecification: Class<*>? = null
     protected var timeoutMs: Long = CTestConfiguration.DEFAULT_TIMEOUT_MS
     protected var customScenarios: MutableList<ExecutionScenario> = mutableListOf()
+    protected var skipIterations = CTestConfiguration.DEFAULT_SKIP_ITERATIONS
 
     /**
      * Number of different test scenarios to be executed
@@ -163,6 +164,14 @@ abstract class Options<OPT : Options<OPT, CTEST>, CTEST : CTestConfiguration> {
      */
     fun addCustomScenario(scenarioBuilder: DSLScenarioBuilder.() -> Unit) =
         addCustomScenario(scenario { scenarioBuilder() })
+
+    /**
+     * Skip the specified number of generated scenarios.
+     * This can be useful for reproducing a bug since scenario generation is deterministic.
+     */
+    fun skipIterations(iterations: Int) = applyAndCast {
+        skipIterations = iterations
+    }
 
     /**
      * Internal, DO NOT USE.

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Reporter.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Reporter.kt
@@ -150,7 +150,10 @@ internal fun StringBuilder.appendExecutionScenario(scenario: ExecutionScenario):
     return this
 }
 
-internal fun StringBuilder.appendFailure(failure: LincheckFailure): StringBuilder {
+internal fun StringBuilder.appendFailure(failure: LincheckFailure, iteration: Int? = null, maxIterations: Int? = null): StringBuilder {
+    iteration?.let {
+        appendln("\n= Iteration $iteration / $maxIterations =")
+    }
     when (failure) {
         is IncorrectResultsFailure -> appendIncorrectResultsFailure(failure)
         is DeadlockWithDumpFailure -> appendDeadlockWithDumpFailure(failure)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/LincheckFailure.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/LincheckFailure.kt
@@ -30,7 +30,10 @@ sealed class LincheckFailure(
     val scenario: ExecutionScenario,
     val trace: Trace?
 ) {
-    override fun toString() = StringBuilder().appendFailure(this).toString()
+    var iteration: Int? = null
+    var maxIterations: Int? = null
+
+    override fun toString() = StringBuilder().appendFailure(this, iteration, maxIterations).toString()
 }
 
 internal class IncorrectResultsFailure(

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedCTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedCTestConfiguration.kt
@@ -36,10 +36,10 @@ abstract class ManagedCTestConfiguration(
     val checkObstructionFreedom: Boolean, val hangingDetectionThreshold: Int, val invocationsPerIteration: Int,
     val guarantees: List<ManagedStrategyGuarantee>, requireStateEquivalenceCheck: Boolean, minimizeFailedScenario: Boolean,
     sequentialSpecification: Class<*>, timeoutMs: Long, val eliminateLocalObjects: Boolean, val verboseTrace: Boolean,
-    customScenarios: List<ExecutionScenario>
+    customScenarios: List<ExecutionScenario>, skipIterations: Int
 ) : CTestConfiguration(
     testClass, iterations, threads, actorsPerThread, actorsBefore, actorsAfter, generatorClass, verifierClass,
-    requireStateEquivalenceCheck, minimizeFailedScenario, sequentialSpecification, timeoutMs, customScenarios
+    requireStateEquivalenceCheck, minimizeFailedScenario, sequentialSpecification, timeoutMs, customScenarios, skipIterations
 ) {
     companion object {
         const val DEFAULT_INVOCATIONS = 10000

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingCTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingCTestConfiguration.kt
@@ -35,10 +35,10 @@ class ModelCheckingCTestConfiguration(testClass: Class<*>, iterations: Int, thre
                                       checkObstructionFreedom: Boolean, hangingDetectionThreshold: Int, invocationsPerIteration: Int,
                                       guarantees: List<ManagedStrategyGuarantee>, requireStateEquivalenceCheck: Boolean, minimizeFailedScenario: Boolean,
                                       sequentialSpecification: Class<*>, timeoutMs: Long, eliminateLocalObjects: Boolean, verboseTrace: Boolean,
-                                      customScenarios: List<ExecutionScenario>
+                                      customScenarios: List<ExecutionScenario>, skipIterations: Int
 ) : ManagedCTestConfiguration(testClass, iterations, threads, actorsPerThread, actorsBefore, actorsAfter, generatorClass, verifierClass,
     checkObstructionFreedom, hangingDetectionThreshold, invocationsPerIteration, guarantees, requireStateEquivalenceCheck,
-    minimizeFailedScenario, sequentialSpecification, timeoutMs, eliminateLocalObjects, verboseTrace, customScenarios) {
+    minimizeFailedScenario, sequentialSpecification, timeoutMs, eliminateLocalObjects, verboseTrace, customScenarios, skipIterations) {
     override fun createStrategy(testClass: Class<*>, scenario: ExecutionScenario, validationFunctions: List<Method>,
                                 stateRepresentationMethod: Method?, verifier: Verifier): Strategy
         = ModelCheckingStrategy(this, testClass, scenario, validationFunctions, stateRepresentationMethod, verifier)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingOptions.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingOptions.kt
@@ -33,6 +33,6 @@ class ModelCheckingOptions : ManagedOptions<ModelCheckingOptions, ModelCheckingC
                 executionGenerator, verifier, checkObstructionFreedom, hangingDetectionThreshold, invocationsPerIteration,
                 guarantees, requireStateEquivalenceImplementationCheck, minimizeFailedScenario,
                 chooseSequentialSpecification(sequentialSpecification, testClass), timeoutMs, eliminateLocalObjects,
-                verboseTrace, customScenarios)
+                verboseTrace, customScenarios, skipIterations)
     }
 }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressCTestConfiguration.kt
@@ -32,9 +32,10 @@ import java.lang.reflect.*
 class StressCTestConfiguration(testClass: Class<*>, iterations: Int, threads: Int, actorsPerThread: Int, actorsBefore: Int, actorsAfter: Int,
                                generatorClass: Class<out ExecutionGenerator>, verifierClass: Class<out Verifier>,
                                val invocationsPerIteration: Int, requireStateEquivalenceCheck: Boolean, minimizeFailedScenario: Boolean,
-                               sequentialSpecification: Class<*>, timeoutMs: Long, customScenarios: List<ExecutionScenario>
+                               sequentialSpecification: Class<*>, timeoutMs: Long, customScenarios: List<ExecutionScenario>,
+                               skipIterations: Int
 ) : CTestConfiguration(testClass, iterations, threads, actorsPerThread, actorsBefore, actorsAfter, generatorClass, verifierClass,
-    requireStateEquivalenceCheck, minimizeFailedScenario, sequentialSpecification, timeoutMs, customScenarios) {
+    requireStateEquivalenceCheck, minimizeFailedScenario, sequentialSpecification, timeoutMs, customScenarios, skipIterations) {
     override fun createStrategy(testClass: Class<*>, scenario: ExecutionScenario, validationFunctions: List<Method>,
                                 stateRepresentationMethod: Method?, verifier: Verifier) =
         StressStrategy(this, testClass, scenario, validationFunctions, stateRepresentationMethod, verifier)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressOptions.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/stress/StressOptions.kt
@@ -40,6 +40,6 @@ open class StressOptions : Options<StressOptions, StressCTestConfiguration>() {
     override fun createTestConfigurations(testClass: Class<*>): StressCTestConfiguration {
         return StressCTestConfiguration(testClass, iterations, threads, actorsPerThread, actorsBefore, actorsAfter, executionGenerator,
                 verifier, invocationsPerIteration, requireStateEquivalenceImplementationCheck, minimizeFailedScenario,
-                chooseSequentialSpecification(sequentialSpecification, testClass), timeoutMs, customScenarios)
+                chooseSequentialSpecification(sequentialSpecification, testClass), timeoutMs, customScenarios, skipIterations)
     }
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/IterationSkippingTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/IterationSkippingTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2021 JetBrains s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>
+ */
+
+package org.jetbrains.kotlinx.lincheck.test
+
+import org.jetbrains.kotlinx.lincheck.annotations.Operation
+import org.jetbrains.kotlinx.lincheck.checkImpl
+import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingOptions
+import org.jetbrains.kotlinx.lincheck.verifier.VerifierState
+import org.junit.Test
+
+class IterationSkippingTest : VerifierState() {
+    var counter = 0
+
+    @Operation
+    fun incrementAndGet(): Int {
+        ++counter
+        return ++counter
+    }
+
+    @Test
+    fun testIterationNumberPresent() {
+        val options = ModelCheckingOptions().minimizeFailedScenario(false).iterations(10)
+        val failure = options.checkImpl(this::class.java)
+        check(failure != null) { "the test should fail" }
+        val log = failure.toString()
+        check("= Iteration 1 / 10 =" in log) { "The number of failing iteration should be present in the log" }
+    }
+
+    @Test
+    fun testSkipIterations() {
+        val options = ModelCheckingOptions()
+            .minimizeFailedScenario(false)
+            .iterations(10)
+            .skipIterations(9)
+        val failure = options.checkImpl(this::class.java)
+        check(failure != null) { "the test should fail" }
+        val log = failure.toString()
+        check("= Iteration 10 / 10 =" in log) { "The number of failing iteration should be present in the log" }
+        check("= Iteration 1 / 10 =" !in log)
+    }
+
+    @Test
+    fun testSkipAllIterations() {
+        val options = ModelCheckingOptions()
+            .minimizeFailedScenario(false)
+            .iterations(10)
+            .skipIterations(10)
+        val failure = options.checkImpl(this::class.java)
+        check(failure == null) { "All iterations are skipped => should be no failure found" }
+    }
+
+    override fun extractState(): Any = counter
+}


### PR DESCRIPTION
* Iteration number is now always present in the incorrect execution log.
* Iterations can be skipped via `Options.skipIterations(iterations)` to reproduce errors faster.