### PR TITLE
Fix LinChecker.check(StressOptionsTest.class)

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ public class MyConcurrentTest {
         .iterations(10)
         .threads(3)
         .logLevel(LoggingLevel.INFO);
-    LinChecker.check(StressOptionsTest.class, opts);
+    LinChecker.check(MyConcurrentTest.class, opts);
   }
 }
 ```


### PR DESCRIPTION
An alternative fix for #115 which was closed by https://github.com/Kotlin/kotlinx-lincheck/pull/115#issuecomment-1038523231

@ndkoval