### PR TITLE
Fix NPE when trying to finish after deadlock detection

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -450,6 +450,7 @@ abstract class ManagedStrategy(
      */
     internal fun beforeLockAcquire(iThread: Int, codeLocation: Int, tracePoint: MonitorEnterTracePoint?, monitor: Any): Boolean {
         if (!isTestThread(iThread)) return true
+        if (inIgnoredSection(iThread)) return false
         newSwitchPoint(iThread, codeLocation, tracePoint)
         // Try to acquire the monitor
         if (!monitorTracker.acquireMonitor(iThread, monitor)) {
@@ -470,6 +471,7 @@ abstract class ManagedStrategy(
      */
     internal fun beforeLockRelease(iThread: Int, codeLocation: Int, tracePoint: MonitorExitTracePoint?, monitor: Any): Boolean {
         if (!isTestThread(iThread)) return true
+        if (inIgnoredSection(iThread)) return false
         monitorTracker.releaseMonitor(monitor)
         traceCollector?.passCodeLocation(tracePoint)
         return false
@@ -505,6 +507,7 @@ abstract class ManagedStrategy(
      */
     internal fun beforeWait(iThread: Int, codeLocation: Int, tracePoint: WaitTracePoint?, monitor: Any, withTimeout: Boolean): Boolean {
         if (!isTestThread(iThread)) return true
+        if (inIgnoredSection(iThread)) return false
         newSwitchPoint(iThread, codeLocation, tracePoint)
         failIfObstructionFreedomIsRequired { "Obstruction-freedom is required but a waiting on a monitor block has been found" }
         if (withTimeout) return false // timeouts occur instantly

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/runner/DeadlockTests.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/runner/DeadlockTests.kt
@@ -58,6 +58,25 @@ class DeadlockOnSynchronizedTest : AbstractLincheckTest(DeadlockWithDumpFailure:
     override fun extractState(): Any = counter
 }
 
+class DeadlockOnSynchronizedWaitTest : AbstractLincheckTest(DeadlockWithDumpFailure::class) {
+    private var lock = Object()
+
+    @Operation
+    fun operation() {
+        synchronized(lock) {
+            lock.wait()
+        }
+    }
+
+    override fun <O : Options<O, *>> O.customize() {
+        actorsBefore(0)
+        minimizeFailedScenario(false)
+        invocationTimeout(200)
+    }
+
+    override fun extractState(): Any = 0 // constant
+}
+
 class LiveLockTest : AbstractLincheckTest(DeadlockWithDumpFailure::class) {
     private var counter = 0
     private val lock1 = AtomicBoolean(false)


### PR DESCRIPTION
Fixes #125.

LinCheck threw NPE when trying to finish safely after deadlock detection to avoid resource leak.
There was already an internal mechanism to prevent blocking operations after an exception but it was not enabled for Java monitors