### PR TITLE
Fix Verifier memory leak

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/LinChecker.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/LinChecker.kt
@@ -64,15 +64,16 @@ class LinChecker (private val testClass: Class<*>, options: Options<*, *>?) {
 
     private fun CTestConfiguration.checkImpl(): LincheckFailure? {
         val exGen = createExecutionGenerator()
+        var isFirstVerifier = true
         for (i in customScenarios.indices) {
-            val verifier = createVerifier(checkStateEquivalence = i == 0)
+            val verifier = createVerifier(checkStateEquivalence = isFirstVerifier).also { isFirstVerifier = false }
             val scenario = customScenarios[i]
             scenario.validate()
             reporter.logIteration(i + 1, customScenarios.size, scenario)
             val failure = scenario.run(this, verifier)
             if (failure != null) return failure
         }
-        var verifier = createVerifier(checkStateEquivalence = true)
+        var verifier = createVerifier(checkStateEquivalence = isFirstVerifier).also { isFirstVerifier = false }
         repeat(iterations) { i ->
             // For performance reasons, verifier re-uses LTS from previous iterations.
             // This behaviour is similar to a memory leak and can potentially cause OutOfMemoryError.

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Result.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Result.kt
@@ -44,38 +44,8 @@ sealed class Result {
 /**
  * Type of result used if the actor invocation returns any value.
  */
-class ValueResult @JvmOverloads constructor(val value: Any?, override val wasSuspended: Boolean = false) : Result() {
-    private val valueClassTransformed: Boolean get() = value?.javaClass?.classLoader is TransformationClassLoader
-    private val serializedObject: ByteArray by lazy(LazyThreadSafetyMode.NONE) {
-        check(value is Serializable?) {
-            "The result should either be a type always loaded by the system class loader " +
-                "(e.g., Int, String, List<T>) or implement Serializable interface; " +
-                "the actual class is ${value?.javaClass}."
-        }
-        if (!valueClassTransformed) {
-            // The object is not transformed
-            value.serialize()
-        } else {
-            // The object is not transformed and should be converted beforehand
-            value.convertForLoader(LinChecker::class.java.classLoader).serialize()
-        }
-    }
-
+data class ValueResult @JvmOverloads constructor(val value: Any?, override val wasSuspended: Boolean = false) : Result() {
     override fun toString() = wasSuspendedPrefix + "$value"
-
-    override fun equals(other: Any?): Boolean {
-        // Check that the classes are equal by names
-        // since they can be loaded via different class loaders.
-        if (javaClass.name != other?.javaClass?.name) return false
-        other as ValueResult
-        // Is `wasSuspended` flag the same?
-        if (wasSuspended != other.wasSuspended) return false
-        // When both value are not transformed, then compare them directly, otherwise serialize to compare
-        return if (!valueClassTransformed && !other.valueClassTransformed) value == other.value
-               else serializedObject.contentEquals(other.serializedObject)
-    }
-
-    override fun hashCode(): Int = if (wasSuspended) 0 else 1  // we cannot use the value here
 }
 
 /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
@@ -291,6 +291,8 @@ private fun Result.convertForLoader(loader: ClassLoader): Result = when (this) {
  */
 internal fun Any?.convertForLoader(loader: ClassLoader) = when {
     this == null -> this
+    this::class.java.classLoader == null -> this // primitive class, no need to convert
+    this::class.java.classLoader == loader -> this // already in this loader
     loader is TransformationClassLoader && !loader.shouldBeTransformed(this.javaClass) -> this
     this is Serializable -> serialize().run { deserialize(loader) }
     else -> error("The result class should either be always loaded by the system class loader and not be transformed," +

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Utils.kt
@@ -142,7 +142,7 @@ internal fun createLincheckResult(res: Any?, wasSuspended: Boolean = false) = wh
     res != null && res is Throwable -> ExceptionResult.create(res.javaClass, wasSuspended)
     res === COROUTINE_SUSPENDED -> Suspended
     res is kotlin.Result<Any?> -> res.toLinCheckResult(wasSuspended)
-    else -> ValueResult(res, wasSuspended)
+    else -> ValueResult(res.convertForLoader(LinChecker::class.java.classLoader), wasSuspended)
 }
 
 private fun kotlin.Result<Any?>.toLinCheckResult(wasSuspended: Boolean) =
@@ -151,7 +151,7 @@ private fun kotlin.Result<Any?>.toLinCheckResult(wasSuspended: Boolean) =
             is Unit -> if (wasSuspended) SuspendedVoidResult else VoidResult
             // Throwable was returned as a successful result
             is Throwable -> ValueResult(value::class.java, wasSuspended)
-            else -> ValueResult(value, wasSuspended)
+            else -> ValueResult(value.convertForLoader(LinChecker::class.java.classLoader), wasSuspended)
         }
     } else ExceptionResult.create(exceptionOrNull()!!.let { it::class.java }, wasSuspended)
 
@@ -254,6 +254,15 @@ internal fun ExecutionScenario.convertForLoader(loader: ClassLoader) = Execution
     postExecution
 )
 
+internal fun ExecutionResult.convertForLoader(loader: ClassLoader) = ExecutionResult(
+        initResults.map { it.convertForLoader(loader) },
+        afterInitStateRepresentation,
+        parallelResultsWithClock.map { results -> results.map { it.convertForLoader(loader) } },
+        afterParallelStateRepresentation,
+        postResults.map { it.convertForLoader(loader) },
+        afterPostStateRepresentation
+)
+
 /**
  * Finds the same method but loaded by the specified (class loader)[loader],
  * the signature can be changed according to the [TransformationClassLoader]'s remapper.
@@ -267,6 +276,19 @@ private fun Method.convertForLoader(loader: ClassLoader): Method {
 
 private fun Class<*>.convertForLoader(loader: TransformationClassLoader): Class<*> = if (isPrimitive) this else loader.loadClass(loader.remapClassName(name))
 
+private fun ResultWithClock.convertForLoader(loader: ClassLoader): ResultWithClock =
+        ResultWithClock(result.convertForLoader(loader), clockOnStart)
+
+private fun Result.convertForLoader(loader: ClassLoader): Result = when (this) {
+    is ValueResult -> ValueResult(value.convertForLoader(loader), wasSuspended)
+    else -> this // does not need to be transformed
+}
+
+/**
+ * Move the value from its current class loader to the specified [loader].
+ * For primitive values, does nothing.
+ * Non-primitive values need to be [Serializable] for this to succeed.
+ */
 internal fun Any?.convertForLoader(loader: ClassLoader) = when {
     this == null -> this
     loader is TransformationClassLoader && !loader.shouldBeTransformed(this.javaClass) -> this

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/runner/ParallelThreadsRunner.kt
@@ -304,11 +304,13 @@ internal open class ParallelThreadsRunner(
             result
         }
         val afterPostStateRepresentation = constructStateRepresentation()
+        // Combine the results and convert them for the standard class loader (if of non-primitive types).
+        // We do not want the byte-code transformation to be known outside of runner and strategy classes.
         val results = ExecutionResult(
             initResults, afterInitStateRepresentation,
             parallelResultsWithClock, afterParallelStateRepresentation,
             postResults, afterPostStateRepresentation
-        )
+        ).convertForLoader(LinChecker::class.java.classLoader)
         return CompletedInvocationResult(results)
     }
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategyStateHolder.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategyStateHolder.kt
@@ -44,32 +44,14 @@ internal object ManagedStrategyStateHolder {
     fun setState(loader: ClassLoader, strategy: ManagedStrategy?, testClass: Class<out Any>) {
         try {
             val clazz = loader.loadClass(ManagedStrategyStateHolder::class.java.canonicalName)
-            clazz.getField("strategy")[null] = strategy
-            clazz.getField("objectManager")[null] = ObjectManager(testClass)
+            clazz.getField(this::strategy.name)[null] = strategy
+            clazz.getField(this::objectManager.name)[null] = ObjectManager(testClass)
             // load transformed java.util.Random class
             val randomClass = loader.loadClass(Random::class.java.canonicalName)
-            clazz.getField("random")[null] = randomClass.getConstructor().newInstance()
+            clazz.getField(this::random.name)[null] = randomClass.getConstructor(Long::class.javaPrimitiveType).newInstance(INITIAL_SEED)
         } catch (e: Throwable) {
             throw IllegalStateException("Cannot set state to ManagedStateHolder", e)
         }
-    }
-
-    /**
-     * Prepare the state for the specified class loader for the next invocation.
-     */
-    fun resetState(loader: ClassLoader, testClass: Class<out Any>) {
-        try {
-            val clazz = loader.loadClass(ManagedStrategyStateHolder::class.java.canonicalName)
-            clazz.getMethod("resetStateImpl", Class::class.java).invoke(null, testClass)
-        } catch (e: Exception) {
-            throw IllegalStateException("Cannot set state to ManagedStateHolder", e)
-        }
-    }
-
-    @JvmStatic
-    fun resetStateImpl(testClass: Class<out Any>) {
-        random!!.setSeed(INITIAL_SEED)
-        objectManager = ObjectManager(testClass)
     }
 }
 

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/transformation/FinalFieldReadingEliminationTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/transformation/FinalFieldReadingEliminationTest.kt
@@ -53,5 +53,5 @@ class FinalFieldReadingEliminationTest : VerifierState() {
 
     override fun extractState(): Any = 0 // constant state
 
-    class ValueHolder(val value: Int) : Serializable
+    data class ValueHolder(val value: Int) : Serializable
 }


### PR DESCRIPTION
Fixed a memory leak between iteration in Lincheck.

The LinCheck Verifier caches scenario results which it already verified to bound computations.
However, this cache was kept between different iterations, essentially resulting in a memory leak.
The cached values from previous iterations can be useful only if the scenario generated in the current iteration is the same as in one of the previous iterations, which is an unlikely event in practice.

The size of the leak can be large for tests of reasonable size. I managed to get a 500Mb leak for a configuration with 3 threads, 2 operations per thread, 1000 invocations per iterations and 500 iterations.

This PR re-creates linearizability verifier for each iteration to avoid this leak