### PR TITLE
VerboseTrace option was removed from the API

### DIFF
--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/CTestConfiguration.kt
@@ -26,7 +26,6 @@ import org.jetbrains.kotlinx.lincheck.execution.*
 import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration.Companion.DEFAULT_ELIMINATE_LOCAL_OBJECTS
-import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration.Companion.DEFAULT_VERBOSE_TRACE
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
 import org.jetbrains.kotlinx.lincheck.strategy.stress.*
 import org.jetbrains.kotlinx.lincheck.verifier.*
@@ -51,8 +50,11 @@ abstract class CTestConfiguration(
     val timeoutMs: Long,
     val customScenarios: List<ExecutionScenario>
 ) {
-    abstract fun createStrategy(testClass: Class<*>, scenario: ExecutionScenario, validationFunctions: List<Method>,
-                                stateRepresentationMethod: Method?, verifier: Verifier): Strategy
+    abstract fun createStrategy(
+        testClass: Class<*>, scenario: ExecutionScenario, validationFunctions: List<Method>,
+        stateRepresentationMethod: Method?, verifier: Verifier
+    ): Strategy
+
     companion object {
         const val DEFAULT_ITERATIONS = 100
         const val DEFAULT_THREADS = 2
@@ -69,23 +71,49 @@ abstract class CTestConfiguration(
 internal fun createFromTestClassAnnotations(testClass: Class<*>): List<CTestConfiguration> {
     val stressConfigurations: List<CTestConfiguration> = testClass.getAnnotationsByType(StressCTest::class.java)
         .map { ann: StressCTest ->
-            StressCTestConfiguration(testClass, ann.iterations,
-                ann.threads, ann.actorsPerThread, ann.actorsBefore, ann.actorsAfter,
-                ann.generator.java, ann.verifier.java, ann.invocationsPerIteration,
-                ann.requireStateEquivalenceImplCheck, ann.minimizeFailedScenario,
-                chooseSequentialSpecification(ann.sequentialSpecification.java, testClass),
-                DEFAULT_TIMEOUT_MS, emptyList()
+            StressCTestConfiguration(
+                testClass = testClass,
+                iterations = ann.iterations,
+                threads = ann.threads,
+                actorsPerThread = ann.actorsPerThread,
+                actorsBefore = ann.actorsBefore,
+                actorsAfter = ann.actorsAfter,
+                generatorClass = ann.generator.java,
+                verifierClass = ann.verifier.java,
+                invocationsPerIteration = ann.invocationsPerIteration,
+                requireStateEquivalenceCheck = ann.requireStateEquivalenceImplCheck,
+                minimizeFailedScenario = ann.minimizeFailedScenario,
+                sequentialSpecification = chooseSequentialSpecification(ann.sequentialSpecification.java, testClass),
+                timeoutMs = DEFAULT_TIMEOUT_MS,
+                customScenarios = emptyList()
             )
         }
-    val modelCheckingConfigurations: List<CTestConfiguration> = testClass.getAnnotationsByType(ModelCheckingCTest::class.java)
-        .map { ann: ModelCheckingCTest ->
-            ModelCheckingCTestConfiguration(testClass, ann.iterations,
-                ann.threads, ann.actorsPerThread, ann.actorsBefore, ann.actorsAfter,
-                ann.generator.java, ann.verifier.java, ann.checkObstructionFreedom, ann.hangingDetectionThreshold,
-                ann.invocationsPerIteration, ManagedCTestConfiguration.DEFAULT_GUARANTEES, ann.requireStateEquivalenceImplCheck,
-                ann.minimizeFailedScenario, chooseSequentialSpecification(ann.sequentialSpecification.java, testClass),
-                DEFAULT_TIMEOUT_MS, DEFAULT_ELIMINATE_LOCAL_OBJECTS, DEFAULT_VERBOSE_TRACE, emptyList()
-            )
-        }
+    val modelCheckingConfigurations: List<CTestConfiguration> =
+        testClass.getAnnotationsByType(ModelCheckingCTest::class.java)
+            .map { ann: ModelCheckingCTest ->
+                ModelCheckingCTestConfiguration(
+                    testClass = testClass,
+                    iterations = ann.iterations,
+                    threads = ann.threads,
+                    actorsPerThread = ann.actorsPerThread,
+                    actorsBefore = ann.actorsBefore,
+                    actorsAfter = ann.actorsAfter,
+                    generatorClass = ann.generator.java,
+                    verifierClass = ann.verifier.java,
+                    checkObstructionFreedom = ann.checkObstructionFreedom,
+                    hangingDetectionThreshold = ann.hangingDetectionThreshold,
+                    invocationsPerIteration = ann.invocationsPerIteration,
+                    guarantees = ManagedCTestConfiguration.DEFAULT_GUARANTEES,
+                    requireStateEquivalenceCheck = ann.requireStateEquivalenceImplCheck,
+                    minimizeFailedScenario = ann.minimizeFailedScenario,
+                    sequentialSpecification = chooseSequentialSpecification(
+                        ann.sequentialSpecification.java,
+                        testClass
+                    ),
+                    timeoutMs = DEFAULT_TIMEOUT_MS,
+                    eliminateLocalObjects = DEFAULT_ELIMINATE_LOCAL_OBJECTS,
+                    customScenarios = emptyList()
+                )
+            }
     return stressConfigurations + modelCheckingConfigurations
 }

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Messages.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Messages.kt
@@ -1,0 +1,29 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2023 JetBrains s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>
+ */
+
+package org.jetbrains.kotlinx.lincheck
+
+object Messages {
+
+    const val DETAILED_PARALLEL_PART = "Detailed parallel part trace:"
+
+    const val PARALLEL_PART = "Parallel part trace:"
+
+}

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/Reporter.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/Reporter.kt
@@ -29,7 +29,7 @@ import org.jetbrains.kotlinx.lincheck.strategy.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.*
 import java.io.*
 
-class Reporter constructor(val logLevel: LoggingLevel) {
+class Reporter constructor(private val logLevel: LoggingLevel) {
     private val out: PrintStream = System.out
     private val outErr: PrintStream = System.err
 

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedCTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedCTestConfiguration.kt
@@ -21,7 +21,6 @@
  */
 package org.jetbrains.kotlinx.lincheck.strategy.managed
 
-import kotlinx.coroutines.*
 import org.jetbrains.kotlinx.lincheck.*
 import org.jetbrains.kotlinx.lincheck.execution.*
 import org.jetbrains.kotlinx.lincheck.verifier.*
@@ -35,7 +34,7 @@ abstract class ManagedCTestConfiguration(
     generatorClass: Class<out ExecutionGenerator>, verifierClass: Class<out Verifier>,
     val checkObstructionFreedom: Boolean, val hangingDetectionThreshold: Int, val invocationsPerIteration: Int,
     val guarantees: List<ManagedStrategyGuarantee>, requireStateEquivalenceCheck: Boolean, minimizeFailedScenario: Boolean,
-    sequentialSpecification: Class<*>, timeoutMs: Long, val eliminateLocalObjects: Boolean, val verboseTrace: Boolean,
+    sequentialSpecification: Class<*>, timeoutMs: Long, val eliminateLocalObjects: Boolean,
     customScenarios: List<ExecutionScenario>
 ) : CTestConfiguration(
     testClass, iterations, threads, actorsPerThread, actorsBefore, actorsAfter, generatorClass, verifierClass,
@@ -46,7 +45,6 @@ abstract class ManagedCTestConfiguration(
         const val DEFAULT_CHECK_OBSTRUCTION_FREEDOM = false
         const val DEFAULT_ELIMINATE_LOCAL_OBJECTS = true
         const val DEFAULT_HANGING_DETECTION_THRESHOLD = 101
-        const val DEFAULT_VERBOSE_TRACE = false
         const val LIVELOCK_EVENTS_THRESHOLD = 10001
         val DEFAULT_GUARANTEES = listOf( // These classes use WeakHashMap, and thus, their code is non-deterministic.
             // Non-determinism should not be present in managed executions, but luckily the classes

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedOptions.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedOptions.kt
@@ -27,7 +27,6 @@ import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration
 import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration.Companion.DEFAULT_GUARANTEES
 import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration.Companion.DEFAULT_HANGING_DETECTION_THRESHOLD
 import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration.Companion.DEFAULT_INVOCATIONS
-import org.jetbrains.kotlinx.lincheck.strategy.managed.ManagedCTestConfiguration.Companion.DEFAULT_VERBOSE_TRACE
 import java.util.*
 
 /**
@@ -38,8 +37,7 @@ abstract class ManagedOptions<OPT : Options<OPT, CTEST>, CTEST : CTestConfigurat
     protected var checkObstructionFreedom = DEFAULT_CHECK_OBSTRUCTION_FREEDOM
     protected var hangingDetectionThreshold = DEFAULT_HANGING_DETECTION_THRESHOLD
     protected val guarantees: MutableList<ManagedStrategyGuarantee> = ArrayList(DEFAULT_GUARANTEES)
-    protected var eliminateLocalObjects: Boolean = DEFAULT_ELIMINATE_LOCAL_OBJECTS;
-    protected var verboseTrace = DEFAULT_VERBOSE_TRACE
+    protected var eliminateLocalObjects: Boolean = DEFAULT_ELIMINATE_LOCAL_OBJECTS
 
     /**
      * Use the specified number of scenario invocations to study interleavings in each iteration.
@@ -79,20 +77,10 @@ abstract class ManagedOptions<OPT : Options<OPT, CTEST>, CTEST : CTestConfigurat
     }
 
     /**
-     * Set to `true` to make Lincheck log all events in an incorrect execution trace.
-     * By default, Lincheck collapses the method invocations that were not interrupted
-     * (e.g., due to a switch to another thread), and omits all the details except for
-     * the method invocation result.
-     */
-    fun verboseTrace(verboseTrace: Boolean = true): OPT = applyAndCast {
-        this.verboseTrace = verboseTrace
-    }
-
-    /**
      * Internal, DO NOT USE.
      */
     internal fun eliminateLocalObjects(eliminateLocalObjects: Boolean) {
-        this.eliminateLocalObjects = eliminateLocalObjects;
+        this.eliminateLocalObjects = eliminateLocalObjects
     }
 
     companion object {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/ManagedStrategy.kt
@@ -224,10 +224,10 @@ abstract class ManagedStrategy(
                 appendln("== Reporting the first execution without execution trace ==")
                 appendln(failingResult.toLincheckFailure(scenario, null))
                 appendln("== Reporting the second execution ==")
-                appendln(loggedResults.toLincheckFailure(scenario, Trace(traceCollector!!.trace, testCfg.verboseTrace)).toString())
+                appendln(loggedResults.toLincheckFailure(scenario, Trace(traceCollector!!.trace)).toString())
             }.toString()
         }
-        return Trace(traceCollector!!.trace, testCfg.verboseTrace)
+        return Trace(traceCollector!!.trace)
     }
 
     /**

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TracePoint.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TracePoint.kt
@@ -28,7 +28,7 @@ import java.math.*
 import kotlin.coroutines.*
 import kotlin.coroutines.intrinsics.*
 
-data class Trace(val trace: List<TracePoint>, val verboseTrace: Boolean)
+data class Trace(val trace: List<TracePoint>)
 
 /**
  * Essentially, a trace is a list of trace points, which represent
@@ -230,7 +230,7 @@ internal class CoroutineCancellationTracePoint(
     }
 
     fun initializeException(e: Throwable) {
-        this.exception = e;
+        this.exception = e
     }
 
     override fun toStringImpl(): String {

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TraceReporter.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/TraceReporter.kt
@@ -36,9 +36,25 @@ internal fun StringBuilder.appendTrace(
     trace: Trace
 ) {
     val startTraceGraphNode = constructTraceGraph(scenario, results, trace)
-    val traceRepresentation = traceGraphToRepresentationList(startTraceGraphNode)
+
+    appendln(Messages.PARALLEL_PART)
+    val traceRepresentation = traceGraphToRepresentationList(startTraceGraphNode, false)
+    appendTraceRepresentation(scenario, traceRepresentation)
+    appendln()
+
+    appendln()
+    appendln(Messages.DETAILED_PARALLEL_PART)
+    val traceRepresentationVerbose = traceGraphToRepresentationList(startTraceGraphNode, true)
+    appendTraceRepresentation(scenario, traceRepresentationVerbose)
+
+    objectNumeration.clear() // clear the numeration at the end to avoid memory leaks
+}
+
+private fun StringBuilder.appendTraceRepresentation(
+    scenario: ExecutionScenario,
+    traceRepresentation: List<TraceEventRepresentation>
+) {
     val traceRepresentationSplitted = splitToColumns(scenario.threads, traceRepresentation)
-    appendln("Parallel part trace:")
     append(printInColumnsCustom(traceRepresentationSplitted) {
         StringBuilder().apply {
             for (i in it.indices) {
@@ -48,7 +64,6 @@ internal fun StringBuilder.appendTrace(
             append(" |")
         }.toString()
     })
-    objectNumeration.clear() // clear the numeration at the end to avoid memory leaks
 }
 
 /**
@@ -61,9 +76,11 @@ private fun splitToColumns(nThreads: Int, traceRepresentation: List<TraceEventRe
         // write message in an appropriate column
         result[columnId].add(event.representation)
         val neededSize = result[columnId].size
-        for (column in result)
-            if (column.size != neededSize)
+        for (column in result) {
+            if (column.size != neededSize) {
                 column.add("")
+            }
+        }
     }
     return result
 }
@@ -100,7 +117,13 @@ private fun constructTraceGraph(scenario: ExecutionScenario, results: ExecutionR
             val nextActor = ++lastHandledActor[iThread]
             // create new actor node actor
             val actorNode = traceGraphNodes.createAndAppend { lastNode ->
-                ActorNode(iThread, lastNode, trace.verboseTrace, 0, scenario.parallelExecution[iThread][nextActor], results[iThread, nextActor])
+                ActorNode(
+                    iThread,
+                    lastNode,
+                    0,
+                    scenario.parallelExecution[iThread][nextActor],
+                    results[iThread, nextActor]
+                )
             }
             actorNodes[iThread][nextActor] = actorNode
             traceGraphNodes.add(actorNode)
@@ -109,8 +132,9 @@ private fun constructTraceGraph(scenario: ExecutionScenario, results: ExecutionR
         when (event) {
             // simpler code for FinishEvent, because it does not have actorId or callStackTrace
             is FinishThreadTracePoint -> traceGraphNodes.createAndAppend { lastNode ->
-                TraceLeafEvent(iThread, lastNode, trace.verboseTrace, 1, event)
+                TraceLeafEvent(iThread, lastNode, 1, event)
             }
+
             else -> {
                 var innerNode: TraceInnerNode = actorNodes[iThread][actorId]!!
                 for (call in event.callStackTrace) {
@@ -120,7 +144,7 @@ private fun constructTraceGraph(scenario: ExecutionScenario, results: ExecutionR
                     val callNode = callNodes.computeIfAbsent(callId) {
                         // create a new call node if needed
                         val result = traceGraphNodes.createAndAppend { lastNode ->
-                            CallNode(iThread, lastNode, trace.verboseTrace, innerNode.callDepth + 1, call.call)
+                            CallNode(iThread, lastNode, innerNode.callDepth + 1, call.call)
                         }
                         // make it a child of the previous node
                         innerNode.addInternalEvent(result)
@@ -130,7 +154,13 @@ private fun constructTraceGraph(scenario: ExecutionScenario, results: ExecutionR
                 }
                 val isLastExecutedEvent = eventId == lastExecutedEvents[iThread]
                 val node = traceGraphNodes.createAndAppend { lastNode ->
-                    TraceLeafEvent(iThread, lastNode, trace.verboseTrace, innerNode.callDepth + 1, event, isLastExecutedEvent)
+                    TraceLeafEvent(
+                        iThread,
+                        lastNode,
+                        innerNode.callDepth + 1,
+                        event,
+                        isLastExecutedEvent
+                    )
                 }
                 innerNode.addInternalEvent(node)
             }
@@ -143,7 +173,8 @@ private fun constructTraceGraph(scenario: ExecutionScenario, results: ExecutionR
                 // insert an ActorResultNode between the last actor event and the next event after it
                 val lastEvent = it.lastInternalEvent
                 val lastEventNext = lastEvent.next
-                val resultNode = ActorResultNode(iThread, lastEvent, trace.verboseTrace, it.callDepth + 1, results[iThread, actorId])
+                val resultNode =
+                    ActorResultNode(iThread, lastEvent, it.callDepth + 1, results[iThread, actorId])
                 it.addInternalEvent(resultNode)
                 resultNode.next = lastEventNext
             }
@@ -160,11 +191,14 @@ private operator fun ExecutionResult?.get(iThread: Int, actorId: Int): Result? =
 private fun <T : TraceNode> MutableList<TraceNode>.createAndAppend(constructor: (lastNode: TraceNode?) -> T): T =
     constructor(lastOrNull()).also { add(it) }
 
-private fun traceGraphToRepresentationList(startNode: TraceNode?): List<TraceEventRepresentation> {
+private fun traceGraphToRepresentationList(
+    startNode: TraceNode?,
+    verboseTrace: Boolean
+): List<TraceEventRepresentation> {
     var curNode: TraceNode? = startNode
     val traceRepresentation = mutableListOf<TraceEventRepresentation>()
     while (curNode != null) {
-        curNode = curNode.addRepresentationTo(traceRepresentation)
+        curNode = curNode.addRepresentationTo(traceRepresentation, verboseTrace)
     }
     return traceRepresentation
 }
@@ -172,17 +206,19 @@ private fun traceGraphToRepresentationList(startNode: TraceNode?): List<TraceEve
 private sealed class TraceNode(
     protected val iThread: Int,
     last: TraceNode?,
-    val verboseTrace: Boolean,
     val callDepth: Int // for tree indentation
 ) {
     // `next` edges form an ordered single-directed event list
     var next: TraceNode? = null
+
     // `lastInternalEvent` helps to skip internal events if an actor or a method call can be compressed
     abstract val lastInternalEvent: TraceNode
+
     // `lastState` helps to find the last state needed for the compression
     abstract val lastState: String?
+
     // whether the internal events should be reported
-    abstract val shouldBeExpanded: Boolean
+    abstract fun shouldBeExpanded(verboseTrace: Boolean): Boolean
 
     init {
         last?.let {
@@ -193,36 +229,46 @@ private sealed class TraceNode(
     /**
      * Adds this node representation to the [traceRepresentation] and returns the next node to be processed.
      */
-    abstract fun addRepresentationTo(traceRepresentation: MutableList<TraceEventRepresentation>): TraceNode?
+    abstract fun addRepresentationTo(
+        traceRepresentation: MutableList<TraceEventRepresentation>,
+        verboseTrace: Boolean
+    ): TraceNode?
 }
 
 private class TraceLeafEvent(
     iThread: Int,
     last: TraceNode?,
-    verboseTrace: Boolean,
     callDepth: Int,
     private val event: TracePoint,
-    lastExecutedEvent: Boolean = false
-) : TraceNode(iThread, last, verboseTrace, callDepth) {
+    private val lastExecutedEvent: Boolean = false
+) : TraceNode(iThread, last, callDepth) {
     override val lastState: String? = if (event is StateRepresentationTracePoint) event.stateRepresentation else null
     override val lastInternalEvent: TraceNode = this
-    override val shouldBeExpanded: Boolean = lastExecutedEvent || event is SwitchEventTracePoint || verboseTrace
+    override fun shouldBeExpanded(verboseTrace: Boolean): Boolean {
+        return lastExecutedEvent || event is SwitchEventTracePoint || verboseTrace
+    }
 
-    override fun addRepresentationTo(traceRepresentation: MutableList<TraceEventRepresentation>): TraceNode? {
+    override fun addRepresentationTo(
+        traceRepresentation: MutableList<TraceEventRepresentation>,
+        verboseTrace: Boolean
+    ): TraceNode? {
         val representation = traceIndentation() + event.toString()
         traceRepresentation.add(TraceEventRepresentation(iThread, representation))
         return next
     }
 }
 
-private abstract class TraceInnerNode(iThread: Int, last: TraceNode?, verboseTrace: Boolean, callDepth: Int)
-    : TraceNode(iThread, last, verboseTrace,callDepth) {
+private abstract class TraceInnerNode(iThread: Int, last: TraceNode?, callDepth: Int) :
+    TraceNode(iThread, last, callDepth) {
     override val lastState: String?
         get() = internalEvents.map { it.lastState }.lastOrNull { it != null }
     override val lastInternalEvent: TraceNode
         get() = if (internalEvents.isEmpty()) this else internalEvents.last().lastInternalEvent
-    override val shouldBeExpanded: Boolean
-        by lazy { internalEvents.any { it.shouldBeExpanded } }
+
+    override fun shouldBeExpanded(verboseTrace: Boolean): Boolean {
+        return internalEvents.any { it.shouldBeExpanded(verboseTrace) }
+    }
+
     private val internalEvents = mutableListOf<TraceNode>()
 
     fun addInternalEvent(node: TraceNode) {
@@ -230,13 +276,22 @@ private abstract class TraceInnerNode(iThread: Int, last: TraceNode?, verboseTra
     }
 }
 
-private class CallNode(iThread: Int, last: TraceNode?, verboseTrace: Boolean, callDepth: Int, private val call: MethodCallTracePoint)
-    : TraceInnerNode(iThread, last, verboseTrace, callDepth) {
+private class CallNode(
+    iThread: Int,
+    last: TraceNode?,
+    callDepth: Int,
+    private val call: MethodCallTracePoint
+) : TraceInnerNode(iThread, last, callDepth) {
     // suspended method contents should be reported
-    override val shouldBeExpanded: Boolean by lazy { call.wasSuspended || super.shouldBeExpanded }
+    override fun shouldBeExpanded(verboseTrace: Boolean): Boolean {
+        return call.wasSuspended || super.shouldBeExpanded(verboseTrace)
+    }
 
-    override fun addRepresentationTo(traceRepresentation: MutableList<TraceEventRepresentation>): TraceNode? =
-        if (!shouldBeExpanded) {
+    override fun addRepresentationTo(
+        traceRepresentation: MutableList<TraceEventRepresentation>,
+        verboseTrace: Boolean
+    ): TraceNode? =
+        if (!shouldBeExpanded(verboseTrace)) {
             traceRepresentation.add(TraceEventRepresentation(iThread, traceIndentation() + "$call"))
             lastState?.let { traceRepresentation.add(stateEventRepresentation(iThread, it)) }
             lastInternalEvent.next
@@ -246,10 +301,18 @@ private class CallNode(iThread: Int, last: TraceNode?, verboseTrace: Boolean, ca
         }
 }
 
-private class ActorNode(iThread: Int, last: TraceNode?, verboseTrace: Boolean, callDepth: Int, private val actor: Actor, private val result: Result?)
-    : TraceInnerNode(iThread, last, verboseTrace, callDepth) {
-    override fun addRepresentationTo(traceRepresentation: MutableList<TraceEventRepresentation>): TraceNode? =
-        if (!shouldBeExpanded) {
+private class ActorNode(
+    iThread: Int,
+    last: TraceNode?,
+    callDepth: Int,
+    private val actor: Actor,
+    private val result: Result?
+) : TraceInnerNode(iThread, last, callDepth) {
+    override fun addRepresentationTo(
+        traceRepresentation: MutableList<TraceEventRepresentation>,
+        verboseTrace: Boolean
+    ): TraceNode? =
+        if (!shouldBeExpanded(verboseTrace)) {
             val representation = "$actor" + if (result != null) ": $result" else ""
             traceRepresentation.add(TraceEventRepresentation(iThread, representation))
             lastState?.let { traceRepresentation.add(stateEventRepresentation(iThread, it)) }
@@ -260,13 +323,20 @@ private class ActorNode(iThread: Int, last: TraceNode?, verboseTrace: Boolean, c
         }
 }
 
-private class ActorResultNode(iThread: Int, last: TraceNode?, verboseTrace: Boolean, callDepth: Int, private val result: Result?)
-    : TraceNode(iThread, last, verboseTrace, callDepth) {
+private class ActorResultNode(
+    iThread: Int,
+    last: TraceNode?,
+    callDepth: Int,
+    private val result: Result?
+) : TraceNode(iThread, last, callDepth) {
     override val lastState: String? = null
     override val lastInternalEvent: TraceNode = this
-    override val shouldBeExpanded: Boolean = false
+    override fun shouldBeExpanded(verboseTrace: Boolean): Boolean = false
 
-    override fun addRepresentationTo(traceRepresentation: MutableList<TraceEventRepresentation>): TraceNode? {
+    override fun addRepresentationTo(
+        traceRepresentation: MutableList<TraceEventRepresentation>,
+        verboseTrace: Boolean
+    ): TraceNode? {
         if (result != null)
             traceRepresentation.add(TraceEventRepresentation(iThread, traceIndentation() + "result: $result"))
         return next

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingCTestConfiguration.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingCTestConfiguration.kt
@@ -34,11 +34,28 @@ class ModelCheckingCTestConfiguration(testClass: Class<*>, iterations: Int, thre
                                       actorsAfter: Int, generatorClass: Class<out ExecutionGenerator>, verifierClass: Class<out Verifier>,
                                       checkObstructionFreedom: Boolean, hangingDetectionThreshold: Int, invocationsPerIteration: Int,
                                       guarantees: List<ManagedStrategyGuarantee>, requireStateEquivalenceCheck: Boolean, minimizeFailedScenario: Boolean,
-                                      sequentialSpecification: Class<*>, timeoutMs: Long, eliminateLocalObjects: Boolean, verboseTrace: Boolean,
+                                      sequentialSpecification: Class<*>, timeoutMs: Long, eliminateLocalObjects: Boolean,
                                       customScenarios: List<ExecutionScenario>
-) : ManagedCTestConfiguration(testClass, iterations, threads, actorsPerThread, actorsBefore, actorsAfter, generatorClass, verifierClass,
-    checkObstructionFreedom, hangingDetectionThreshold, invocationsPerIteration, guarantees, requireStateEquivalenceCheck,
-    minimizeFailedScenario, sequentialSpecification, timeoutMs, eliminateLocalObjects, verboseTrace, customScenarios) {
+) : ManagedCTestConfiguration(
+    testClass = testClass,
+    iterations = iterations,
+    threads = threads,
+    actorsPerThread = actorsPerThread,
+    actorsBefore = actorsBefore,
+    actorsAfter = actorsAfter,
+    generatorClass = generatorClass,
+    verifierClass = verifierClass,
+    checkObstructionFreedom = checkObstructionFreedom,
+    hangingDetectionThreshold = hangingDetectionThreshold,
+    invocationsPerIteration = invocationsPerIteration,
+    guarantees = guarantees,
+    requireStateEquivalenceCheck = requireStateEquivalenceCheck,
+    minimizeFailedScenario = minimizeFailedScenario,
+    sequentialSpecification = sequentialSpecification,
+    timeoutMs = timeoutMs,
+    eliminateLocalObjects = eliminateLocalObjects,
+    customScenarios = customScenarios
+) {
     override fun createStrategy(testClass: Class<*>, scenario: ExecutionScenario, validationFunctions: List<Method>,
                                 stateRepresentationMethod: Method?, verifier: Verifier): Strategy
         = ModelCheckingStrategy(this, testClass, scenario, validationFunctions, stateRepresentationMethod, verifier)

--- a/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingOptions.kt
+++ b/src/jvm/main/org/jetbrains/kotlinx/lincheck/strategy/managed/modelchecking/ModelCheckingOptions.kt
@@ -29,10 +29,25 @@ import org.jetbrains.kotlinx.lincheck.strategy.managed.*
  */
 class ModelCheckingOptions : ManagedOptions<ModelCheckingOptions, ModelCheckingCTestConfiguration>() {
     override fun createTestConfigurations(testClass: Class<*>): ModelCheckingCTestConfiguration {
-        return ModelCheckingCTestConfiguration(testClass, iterations, threads, actorsPerThread, actorsBefore, actorsAfter,
-                executionGenerator, verifier, checkObstructionFreedom, hangingDetectionThreshold, invocationsPerIteration,
-                guarantees, requireStateEquivalenceImplementationCheck, minimizeFailedScenario,
-                chooseSequentialSpecification(sequentialSpecification, testClass), timeoutMs, eliminateLocalObjects,
-                verboseTrace, customScenarios)
+        return ModelCheckingCTestConfiguration(
+            testClass = testClass,
+            iterations = iterations,
+            threads = threads,
+            actorsPerThread = actorsPerThread,
+            actorsBefore = actorsBefore,
+            actorsAfter = actorsAfter,
+            generatorClass = executionGenerator,
+            verifierClass = verifier,
+            checkObstructionFreedom = checkObstructionFreedom,
+            hangingDetectionThreshold = hangingDetectionThreshold,
+            invocationsPerIteration = invocationsPerIteration,
+            guarantees = guarantees,
+            requireStateEquivalenceCheck = requireStateEquivalenceImplementationCheck,
+            minimizeFailedScenario = minimizeFailedScenario,
+            sequentialSpecification = chooseSequentialSpecification(sequentialSpecification, testClass),
+            timeoutMs = timeoutMs,
+            eliminateLocalObjects = eliminateLocalObjects,
+            customScenarios = customScenarios
+        )
     }
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/CapturedValueRepresentationTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/CapturedValueRepresentationTest.kt
@@ -25,6 +25,7 @@ import org.jetbrains.kotlinx.lincheck.annotations.Operation
 import org.jetbrains.kotlinx.lincheck.checkImpl
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingOptions
 import org.jetbrains.kotlinx.lincheck.test.*
+import org.jetbrains.kotlinx.lincheck.test.util.logWithoutVerbosePart
 import org.jetbrains.kotlinx.lincheck.verifier.VerifierState
 import org.junit.Test
 
@@ -66,7 +67,7 @@ class CapturedValueRepresentationTest : VerifierState() {
         val log = failure.toString()
         check(" OuterDataClass@1" in log)
         check(" InnerClass@1" in log)
-        check(log.split(" InnerClass@1").size - 1 == 2) { "two reads of innerClass should return same result" }
+        check(logWithoutVerbosePart(log).split(" InnerClass@1").size - 1 == 2) { "two reads of innerClass should return same result" }
         check(" InnerClass@2" in log) { "Two different InnerClass objects were read, but the same was reported" }
         check(" int[]@1" in log)
         check(" String[]@1" in log)

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/CoroutineCancellationTraceReportingTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/CoroutineCancellationTraceReportingTest.kt
@@ -53,7 +53,6 @@ class CoroutineCancellationTraceReportingTest : VerifierState() {
             .actorsPerThread(1)
             .actorsBefore(0)
             .actorsAfter(0)
-            .verboseTrace(true)
             .checkImpl(this::class.java)
         checkNotNull(failure) { "the test should fail" }
         val log = failure.toString()

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/MethodReportingTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/MethodReportingTest.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlinx.lincheck.annotations.Operation
 import org.jetbrains.kotlinx.lincheck.strategy.managed.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
 import org.jetbrains.kotlinx.lincheck.test.*
+import org.jetbrains.kotlinx.lincheck.test.util.logWithoutVerbosePart
 import org.jetbrains.kotlinx.lincheck.verifier.*
 import org.junit.*
 import java.lang.StringBuilder
@@ -104,7 +105,7 @@ class CaughtExceptionMethodReportingTest : VerifierState() {
     fun operation(): Int {
         try {
             return badMethod()
-        } catch(e: Throwable) {
+        } catch (e: Throwable) {
             counter++
             return counter++
         }
@@ -126,7 +127,7 @@ class CaughtExceptionMethodReportingTest : VerifierState() {
         val failure = options.checkImpl(this::class.java)
         check(failure != null) { "the test should fail" }
         val log = StringBuilder().appendFailure(failure).toString()
-        check("useless" !in log) { "Due to bad call stack these accesses appear to be in the same method as thread switches" }
+        check("useless" !in logWithoutVerbosePart(log)) { "Due to bad call stack these accesses appear to be in the same method as thread switches" }
         check("badMethod(): threw NotImplementedError" in log) { "thrown exception is not shown properly" }
         checkTraceHasNoLincheckEvents(log)
     }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/ObstructionFreedomRepresentationTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/ObstructionFreedomRepresentationTest.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlinx.lincheck.annotations.Operation
 import org.jetbrains.kotlinx.lincheck.strategy.managed.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
 import org.jetbrains.kotlinx.lincheck.test.*
+import org.jetbrains.kotlinx.lincheck.test.util.logWithoutVerbosePart
 import org.jetbrains.kotlinx.lincheck.verifier.*
 import org.junit.*
 import java.lang.StringBuilder
@@ -97,7 +98,7 @@ class ObstructionFreedomSynchronizedRepresentationTest : VerifierState() {
         val failure = options.checkImpl(this::class.java)
         check(failure != null) { "the test should fail" }
         val log = StringBuilder().appendFailure(failure).toString()
-        check(log.split("MONITORENTER").size - 1 == 2) { "MONITORENTER should be reported twice" }
+        check(logWithoutVerbosePart(log).split("MONITORENTER").size - 1 == 2) { "MONITORENTER should be reported twice" }
         checkTraceHasNoLincheckEvents(log)
     }
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/StateRepresentationTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/StateRepresentationTest.kt
@@ -21,7 +21,6 @@
  */
 package org.jetbrains.kotlinx.lincheck.test.representation
 
-import kotlinx.atomicfu.*
 import org.jetbrains.kotlinx.lincheck.annotations.Operation
 import org.jetbrains.kotlinx.lincheck.annotations.StateRepresentation
 import org.jetbrains.kotlinx.lincheck.appendFailure
@@ -30,6 +29,7 @@ import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelChecki
 import org.jetbrains.kotlinx.lincheck.strategy.stress.*
 import org.jetbrains.kotlinx.lincheck.strategy.IncorrectResultsFailure
 import org.jetbrains.kotlinx.lincheck.test.*
+import org.jetbrains.kotlinx.lincheck.test.util.logWithoutVerbosePart
 import org.jetbrains.kotlinx.lincheck.verifier.VerifierState
 import org.junit.Test
 import java.lang.IllegalStateException
@@ -65,7 +65,7 @@ open class ModelCheckingStateReportingTest {
         check("STATE: 0" in log)
         check("STATE: 1" in log)
         check("STATE: 4" in log)
-        check(log.split("incrementAndGet(): 1").size - 1 == 1) { "A method call is logged twice in the trace" }
+        check(logWithoutVerbosePart(log).split("incrementAndGet(): 1").size - 1 == 1) { "A method call is logged twice in the trace" }
         checkTraceHasNoLincheckEvents(log)
     }
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/SuspendTraceReportingTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/SuspendTraceReportingTest.kt
@@ -21,12 +21,12 @@
  */
 package org.jetbrains.kotlinx.lincheck.test.representation
 
-import kotlinx.coroutines.*
 import kotlinx.coroutines.sync.*
 import org.jetbrains.kotlinx.lincheck.*
 import org.jetbrains.kotlinx.lincheck.annotations.Operation
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
 import org.jetbrains.kotlinx.lincheck.test.*
+import org.jetbrains.kotlinx.lincheck.test.util.logWithoutVerbosePart
 import org.jetbrains.kotlinx.lincheck.verifier.*
 import org.junit.*
 
@@ -69,7 +69,7 @@ class SuspendTraceReportingTest : VerifierState() {
         val log = failure.toString()
         check("label" !in log) { "suspend state machine related fields should not be reported" }
         check("L$0" !in log) { "suspend state machine related fields should not be reported" }
-        check(log.numberOfOccurrences("foo()") == 2) {
+        check(logWithoutVerbosePart(log).numberOfOccurrences("foo()") == 2) {
             "suspended function should be mentioned exactly twice (once in parallel and once in parallel execution)"
         }
         check("barStarted.READ: true" in log) { "this code location after suspension should be reported" }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/SwitchAsFirstMethodEventTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/SwitchAsFirstMethodEventTest.kt
@@ -25,6 +25,7 @@ import org.jetbrains.kotlinx.lincheck.*
 import org.jetbrains.kotlinx.lincheck.annotations.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
 import org.jetbrains.kotlinx.lincheck.test.*
+import org.jetbrains.kotlinx.lincheck.test.util.logWithoutVerbosePart
 import org.junit.*
 import java.lang.StringBuilder
 
@@ -70,12 +71,15 @@ class SwitchAsFirstMethodEventTest {
         check(failure != null) { "the test should fail" }
         val log = StringBuilder().appendFailure(failure).toString()
         check(SwitchAsFirstMethodEventTest::incAndGet.name in log)
-        check(SwitchAsFirstMethodEventTest::incAndGetImpl.name !in log) {
+
+        val logWithoutVerbosePart = logWithoutVerbosePart(log)
+        check(SwitchAsFirstMethodEventTest::incAndGetImpl.name !in logWithoutVerbosePart) {
             "When the switch is lifted out of methods, there is no point at reporting this method"
         }
-        check("incrementAndGet" !in log) {
+        check("incrementAndGet" !in logWithoutVerbosePart) {
             "When the switch is lifted out of methods, there is no point at reporting this method"
         }
+
         checkTraceHasNoLincheckEvents(log)
     }
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/VerboseTraceTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/representation/VerboseTraceTest.kt
@@ -24,10 +24,11 @@ import org.jetbrains.kotlinx.lincheck.*
 import org.jetbrains.kotlinx.lincheck.annotations.*
 import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.*
 import org.jetbrains.kotlinx.lincheck.test.*
+import org.jetbrains.kotlinx.lincheck.test.util.logVerbosePart
 import org.junit.*
 
 /**
- * This test checks `verboseTrace` option that makes Lincheck log all execution events.
+ * This test checks that makes Lincheck log all execution events in detailed part of output.
  */
 class VerboseTraceTest {
     private var levelZeroCounter = 0
@@ -60,17 +61,23 @@ class VerboseTraceTest {
             .actorsBefore(0)
             .actorsPerThread(1)
             .requireStateEquivalenceImplCheck(false)
-            .verboseTrace(true)
             .checkImpl(this::class.java)
         checkNotNull(failure) { "test should fail" }
         val log = failure.toString()
-        check("  criticalSection" in log) { "An intermediate method call was not logged or has an incorrect indentation" }
-        check("    counter.READ" in log)
-        check("  levelZeroCounter" in log)
-        check("  levelOneEvent" in log) { "An intermediate method call was not logged or has an incorrect indentation" }
-        check("    levelOneCounter" in log)
-        check("    levelTwoEvent" in log) { "An intermediate method call was not logged or has an incorrect indentation" }
-        check("      levelTwoCounter" in log)
+
+        check(Messages.PARALLEL_PART in log) { "No short trace in log output" }
+        check(Messages.DETAILED_PARALLEL_PART in log) { "No verbose trace in log output" }
+
+        val verboseTraceLog = logVerbosePart(log)
+
+        check("  criticalSection" in verboseTraceLog) { "An intermediate method call was not logged or has an incorrect indentation" }
+        check("    counter.READ" in verboseTraceLog)
+        check("  levelZeroCounter" in verboseTraceLog)
+        check("  levelOneEvent" in verboseTraceLog) { "An intermediate method call was not logged or has an incorrect indentation" }
+        check("    levelOneCounter" in verboseTraceLog)
+        check("    levelTwoEvent" in verboseTraceLog) { "An intermediate method call was not logged or has an incorrect indentation" }
+        check("      levelTwoCounter" in verboseTraceLog)
+
         checkTraceHasNoLincheckEvents(log)
     }
 }

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/strategy/modelchecking/SingletonCollectionInTraceTest.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/strategy/modelchecking/SingletonCollectionInTraceTest.kt
@@ -52,7 +52,6 @@ class SingletonCollectionInTraceTest {
     fun modelCheckingTest() {
         val failure = ModelCheckingOptions()
             .iterations(1)
-            .verboseTrace(true)
             .checkImpl(this::class.java)
         val message = failure.toString()
         assert("SingletonList" !in message)

--- a/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/util/TestUtils.kt
+++ b/src/jvm/test/org/jetbrains/kotlinx/lincheck/test/util/TestUtils.kt
@@ -1,0 +1,27 @@
+/*
+ * Lincheck
+ *
+ * Copyright (C) 2019 - 2023 JetBrains s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>
+ */
+
+package org.jetbrains.kotlinx.lincheck.test.util
+
+import org.jetbrains.kotlinx.lincheck.Messages
+
+internal fun logWithoutVerbosePart(log: String) = log.substringBefore(Messages.DETAILED_PARALLEL_PART)
+
+internal fun logVerbosePart(log: String) = log.substringAfter(Messages.DETAILED_PARALLEL_PART)


### PR DESCRIPTION
VerboseTrace option was removed from the API. Log output now contains both standard and verbose traces.